### PR TITLE
fix(#1): Derive userType from profile type for user creation

### DIFF
--- a/application/src/main/java/com/knight/application/rest/bank/BankAdminController.java
+++ b/application/src/main/java/com/knight/application/rest/bank/BankAdminController.java
@@ -626,9 +626,18 @@ public class BankAdminController {
 
         ProfileId profId = ProfileId.fromUrn(profileId);
 
+        // Determine userType based on profileType
+        ProfileSummary profile = profileQueries.getProfileSummary(profId);
+        String userType = switch (profile.profileType()) {
+            case "ONLINE" -> "CLIENT_USER";
+            case "INDIRECT" -> "INDIRECT_USER";
+            default -> throw new IllegalArgumentException(
+                "Cannot add users to " + profile.profileType() + " profiles");
+        };
+
         CreateUserCmd createCmd = new CreateUserCmd(
             request.loginId(), request.email(), request.firstName(), request.lastName(),
-            "INDIRECT_USER", "AUTH0", profId, request.roles(), createdBy
+            userType, "AUTH0", profId, request.roles(), createdBy
         );
 
         UserId userId = userCommands.createUser(createCmd);

--- a/application/src/test/java/com/knight/application/rest/users/UserControllerE2ETest.java
+++ b/application/src/test/java/com/knight/application/rest/users/UserControllerE2ETest.java
@@ -145,7 +145,7 @@ class UserControllerE2ETest {
     private ProfileId createTestProfile() {
         Profile profile = Profile.create(
             testClient.clientId(),
-            ProfileType.SERVICING,
+            ProfileType.ONLINE,
             "system"
         );
         profileRepository.save(profile);
@@ -449,7 +449,7 @@ class UserControllerE2ETest {
                 .andExpect(jsonPath("$.firstName").value("Details"))
                 .andExpect(jsonPath("$.lastName").value("User"))
                 .andExpect(jsonPath("$.status").value("PENDING_VERIFICATION"))
-                .andExpect(jsonPath("$.userType").value("INDIRECT_USER"))
+                .andExpect(jsonPath("$.userType").value("CLIENT_USER"))
                 .andExpect(jsonPath("$.identityProvider").value("AUTH0"))
                 .andExpect(jsonPath("$.profileId").value(testProfileId.urn()))
                 .andExpect(jsonPath("$.roles").isArray())


### PR DESCRIPTION
## Summary
- Fixes issue where `BankAdminController.addUserToProfile()` hardcoded `INDIRECT_USER` for all profiles
- Now correctly determines userType based on profile type:
  - `ONLINE` profiles → `CLIENT_USER`
  - `INDIRECT` profiles → `INDIRECT_USER`
  - `SERVICING` profiles → rejected (no users allowed)
- Updated tests to use ONLINE profile type and expect CLIENT_USER

## Test plan
- [x] All existing tests pass
- [x] UserControllerE2ETest updated to test ONLINE profile with CLIENT_USER
- [x] Coverage verification passed (89% line, 80% branch)

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)