### PR TITLE
feat: Add email OTP verification to FTR flow

### DIFF
--- a/client-login/conf.d/default.conf
+++ b/client-login/conf.d/default.conf
@@ -501,6 +501,191 @@ server {
         }
     }
 
+    # ============================================
+    # FTR (First-Time Registration) API Endpoints
+    # Proxied to auth-service with CORS protection
+    # ============================================
+
+    # FTR - Check user status and onboarding requirements
+    location /api/ftr/check {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/ftr/check;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # FTR - Send OTP for email verification
+    location /api/ftr/send-otp {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/ftr/send-otp;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # FTR - Verify OTP code
+    location /api/ftr/verify-otp {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/ftr/verify-otp;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # FTR - Set password
+    location /api/ftr/set-password {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/ftr/set-password;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # FTR - Complete registration
+    location /api/ftr/complete {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/ftr/complete;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
     # Forgot password - send password reset email
     location /api/auth/forgot-password {
         content_by_lua_block {


### PR DESCRIPTION
## Summary
- Wire up the existing `screen-otp` HTML with JavaScript handlers for email verification during first-time registration
- Implement FTR API calls (check, send-otp, verify-otp, set-password, complete)
- Add OTP countdown timer with expiration handling
- Add nginx proxy endpoints for all FTR API routes with CORS and CSRF protection

## Changes
### JavaScript (login/js/app.js)
- Add `otp` screen to screens object
- Add FTR state variables (`loginId`, `otpCountdownInterval`, `otpExpiresAt`, `isFtr`)
- Implement FTR API functions: `ftrCheck()`, `ftrSendOtp()`, `ftrVerifyOtp()`, `ftrSetPassword()`, `ftrComplete()`
- Add OTP countdown timer logic with `startOtpCountdown()`, `updateOtpCountdown()`, `stopOtpCountdown()`
- Add OTP screen handlers: `showOtpScreen()`, `handleOtpFormSubmit()`, `handleResendOtp()`, `handleOtpChangeEmail()`
- Update `handleEmailSubmit()` to route new users through FTR flow with email verification
- Update `handlePasswordSubmit()` to use FTR API when in FTR flow

### Nginx (conf.d/default.conf)
- Add proxy endpoints for FTR API:
  - `/api/ftr/check` - Check user status and onboarding requirements
  - `/api/ftr/send-otp` - Send OTP for email verification
  - `/api/ftr/verify-otp` - Verify OTP code
  - `/api/ftr/set-password` - Set password
  - `/api/ftr/complete` - Complete registration

## Test Plan
- [ ] New user enters email → OTP is sent → OTP screen is displayed
- [ ] User enters correct OTP → Email verified → Password screen is displayed
- [ ] User enters wrong OTP → Error is shown with remaining attempts
- [ ] OTP countdown timer works and shows expiration
- [ ] Resend OTP button works and resets timer
- [ ] Change email link returns to email screen
- [ ] Password setup uses FTR API when in FTR flow
- [ ] Returning users continue to use existing login flow

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)