### PR TITLE
feat: Passkey (WebAuthn) Enrollment and Authentication

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
 
+        <!-- WebAuthn/Passkey support -->
+        <dependency>
+            <groupId>com.webauthn4j</groupId>
+            <artifactId>webauthn4j-core</artifactId>
+        </dependency>
+
         <!-- Database -->
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>

--- a/application/src/main/java/com/knight/application/persistence/passkeys/entity/PasskeyEntity.java
+++ b/application/src/main/java/com/knight/application/persistence/passkeys/entity/PasskeyEntity.java
@@ -1,0 +1,71 @@
+package com.knight.application.persistence.passkeys.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "passkeys")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasskeyEntity {
+
+    @Id
+    @Column(name = "passkey_id", nullable = false)
+    private UUID passkeyId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "credential_id", nullable = false, unique = true, length = 1024)
+    private String credentialId;
+
+    @Column(name = "public_key", nullable = false, length = 2048)
+    private String publicKey;
+
+    @Column(name = "aaguid", length = 36)
+    private String aaguid;
+
+    @Column(name = "display_name", nullable = false, length = 255)
+    private String displayName;
+
+    @Column(name = "sign_count", nullable = false)
+    private long signCount;
+
+    @Column(name = "user_verification", nullable = false)
+    private boolean userVerification;
+
+    @Column(name = "backup_eligible", nullable = false)
+    private boolean backupEligible;
+
+    @Column(name = "backup_state", nullable = false)
+    private boolean backupState;
+
+    @Column(name = "transports", length = 255)
+    private String transports;  // Comma-separated list
+
+    @Column(name = "last_used_at")
+    private Instant lastUsedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) createdAt = Instant.now();
+        if (updatedAt == null) updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/application/src/main/java/com/knight/application/persistence/passkeys/mapper/PasskeyMapper.java
+++ b/application/src/main/java/com/knight/application/persistence/passkeys/mapper/PasskeyMapper.java
@@ -1,0 +1,58 @@
+package com.knight.application.persistence.passkeys.mapper;
+
+import com.knight.application.persistence.passkeys.entity.PasskeyEntity;
+import com.knight.domain.users.aggregate.Passkey;
+import com.knight.domain.users.types.PasskeyId;
+import com.knight.platform.sharedkernel.UserId;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class PasskeyMapper {
+
+    public PasskeyEntity toEntity(Passkey passkey) {
+        PasskeyEntity entity = new PasskeyEntity();
+        entity.setPasskeyId(passkey.id().value());
+        entity.setUserId(UUID.fromString(passkey.userId().id()));
+        entity.setCredentialId(passkey.credentialId());
+        entity.setPublicKey(passkey.publicKey());
+        entity.setAaguid(passkey.aaguid());
+        entity.setDisplayName(passkey.displayName());
+        entity.setSignCount(passkey.signCount());
+        entity.setUserVerification(passkey.userVerification());
+        entity.setBackupEligible(passkey.backupEligible());
+        entity.setBackupState(passkey.backupState());
+        entity.setTransports(String.join(",", passkey.transports()));
+        entity.setLastUsedAt(passkey.lastUsedAt());
+        entity.setCreatedAt(passkey.createdAt());
+        entity.setUpdatedAt(passkey.updatedAt());
+        return entity;
+    }
+
+    public Passkey toDomain(PasskeyEntity entity) {
+        PasskeyId passkeyId = new PasskeyId(entity.getPasskeyId());
+        UserId userId = UserId.of(entity.getUserId().toString());
+
+        String[] transports = entity.getTransports() != null && !entity.getTransports().isEmpty()
+            ? entity.getTransports().split(",")
+            : new String[0];
+
+        return Passkey.reconstitute(
+            passkeyId,
+            userId,
+            entity.getCredentialId(),
+            entity.getPublicKey(),
+            entity.getAaguid(),
+            entity.getDisplayName(),
+            entity.getSignCount(),
+            entity.isUserVerification(),
+            entity.isBackupEligible(),
+            entity.isBackupState(),
+            transports,
+            entity.getLastUsedAt(),
+            entity.getCreatedAt(),
+            entity.getUpdatedAt()
+        );
+    }
+}

--- a/application/src/main/java/com/knight/application/persistence/passkeys/repository/PasskeyJpaRepository.java
+++ b/application/src/main/java/com/knight/application/persistence/passkeys/repository/PasskeyJpaRepository.java
@@ -1,0 +1,23 @@
+package com.knight.application.persistence.passkeys.repository;
+
+import com.knight.application.persistence.passkeys.entity.PasskeyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface PasskeyJpaRepository extends JpaRepository<PasskeyEntity, UUID> {
+
+    Optional<PasskeyEntity> findByCredentialId(String credentialId);
+
+    List<PasskeyEntity> findByUserId(UUID userId);
+
+    int countByUserId(UUID userId);
+
+    boolean existsByUserId(UUID userId);
+
+    void deleteByUserId(UUID userId);
+}

--- a/application/src/main/java/com/knight/application/persistence/passkeys/repository/PasskeyRepositoryAdapter.java
+++ b/application/src/main/java/com/knight/application/persistence/passkeys/repository/PasskeyRepositoryAdapter.java
@@ -1,0 +1,72 @@
+package com.knight.application.persistence.passkeys.repository;
+
+import com.knight.application.persistence.passkeys.mapper.PasskeyMapper;
+import com.knight.domain.users.aggregate.Passkey;
+import com.knight.domain.users.repository.PasskeyRepository;
+import com.knight.domain.users.types.PasskeyId;
+import com.knight.platform.sharedkernel.UserId;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Repository
+@Transactional
+public class PasskeyRepositoryAdapter implements PasskeyRepository {
+
+    private final PasskeyJpaRepository jpaRepository;
+    private final PasskeyMapper mapper;
+
+    public PasskeyRepositoryAdapter(PasskeyJpaRepository jpaRepository, PasskeyMapper mapper) {
+        this.jpaRepository = jpaRepository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void save(Passkey passkey) {
+        jpaRepository.save(mapper.toEntity(passkey));
+    }
+
+    @Override
+    public Optional<Passkey> findById(PasskeyId passkeyId) {
+        return jpaRepository.findById(passkeyId.value())
+            .map(mapper::toDomain);
+    }
+
+    @Override
+    public Optional<Passkey> findByCredentialId(String credentialId) {
+        return jpaRepository.findByCredentialId(credentialId)
+            .map(mapper::toDomain);
+    }
+
+    @Override
+    public List<Passkey> findByUserId(UserId userId) {
+        return jpaRepository.findByUserId(UUID.fromString(userId.id()))
+            .stream()
+            .map(mapper::toDomain)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public int countByUserId(UserId userId) {
+        return jpaRepository.countByUserId(UUID.fromString(userId.id()));
+    }
+
+    @Override
+    public boolean existsByUserId(UserId userId) {
+        return jpaRepository.existsByUserId(UUID.fromString(userId.id()));
+    }
+
+    @Override
+    public void deleteById(PasskeyId passkeyId) {
+        jpaRepository.deleteById(passkeyId.value());
+    }
+
+    @Override
+    public void deleteByUserId(UserId userId) {
+        jpaRepository.deleteByUserId(UUID.fromString(userId.id()));
+    }
+}

--- a/application/src/main/java/com/knight/application/persistence/users/entity/UserEntity.java
+++ b/application/src/main/java/com/knight/application/persistence/users/entity/UserEntity.java
@@ -75,6 +75,15 @@ public class UserEntity {
     @Column(name = "deactivation_reason", length = 500)
     private String deactivationReason;
 
+    @Column(name = "passkey_offered", nullable = false)
+    private boolean passkeyOffered;
+
+    @Column(name = "passkey_enrolled", nullable = false)
+    private boolean passkeyEnrolled;
+
+    @Column(name = "passkey_has_uv", nullable = false)
+    private boolean passkeyHasUv;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 

--- a/application/src/main/java/com/knight/application/persistence/users/mapper/UserMapper.java
+++ b/application/src/main/java/com/knight/application/persistence/users/mapper/UserMapper.java
@@ -36,6 +36,9 @@ public class UserMapper {
         entity.setLockedBy(user.lockedBy());
         entity.setLockedAt(user.lockedAt());
         entity.setDeactivationReason(user.deactivationReason());
+        entity.setPasskeyOffered(user.passkeyOffered());
+        entity.setPasskeyEnrolled(user.passkeyEnrolled());
+        entity.setPasskeyHasUv(user.passkeyHasUv());
         entity.setCreatedAt(user.createdAt());
         entity.setCreatedBy(user.createdBy());
         entity.setUpdatedAt(user.updatedAt());
@@ -83,6 +86,9 @@ public class UserMapper {
             entity.getLockedBy(),
             entity.getLockedAt(),
             entity.getDeactivationReason(),
+            entity.isPasskeyOffered(),
+            entity.isPasskeyEnrolled(),
+            entity.isPasskeyHasUv(),
             entity.getCreatedAt(),
             entity.getCreatedBy(),
             entity.getUpdatedAt()

--- a/application/src/main/java/com/knight/application/rest/login/PasskeyController.java
+++ b/application/src/main/java/com/knight/application/rest/login/PasskeyController.java
@@ -1,0 +1,362 @@
+package com.knight.application.rest.login;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.knight.application.rest.login.dto.*;
+import com.knight.application.service.passkey.*;
+import com.knight.domain.users.aggregate.User;
+import com.knight.domain.users.repository.UserRepository;
+import com.knight.platform.sharedkernel.UserId;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * Controller for WebAuthn/Passkey operations.
+ * Handles passkey registration (enrollment) and authentication.
+ */
+@RestController
+@RequestMapping("/api/login/passkey")
+public class PasskeyController {
+
+    private final PasskeyService passkeyService;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    public PasskeyController(
+            PasskeyService passkeyService,
+            UserRepository userRepository,
+            ObjectMapper objectMapper) {
+        this.passkeyService = passkeyService;
+        this.userRepository = userRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Generate registration options for passkey enrollment.
+     * Called when user initiates passkey setup.
+     */
+    @PostMapping("/register/options")
+    public ResponseEntity<ObjectNode> getRegistrationOptions(
+            @Valid @RequestBody PasskeyRegisterOptionsRequest request) {
+        try {
+            // Find user by login ID
+            User user = userRepository.findByLoginId(request.loginId())
+                .orElse(null);
+
+            if (user == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(errorResponse("user_not_found", "User not found"));
+            }
+
+            // Check user status
+            if (user.status() == User.Status.LOCKED) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(errorResponse("account_locked", "Account is locked"));
+            }
+
+            RegistrationOptionsResponse options = passkeyService.generateRegistrationOptions(user.id());
+
+            ObjectNode response = objectMapper.createObjectNode();
+            response.put("challengeId", options.challengeId());
+            response.put("challenge", options.challenge());
+
+            ObjectNode rp = objectMapper.createObjectNode();
+            rp.put("id", options.rpId());
+            rp.put("name", options.rpName());
+            response.set("rp", rp);
+
+            ObjectNode userNode = objectMapper.createObjectNode();
+            userNode.put("id", options.userId());
+            userNode.put("name", options.userName());
+            userNode.put("displayName", options.userDisplayName());
+            response.set("user", userNode);
+
+            response.put("timeout", options.timeout());
+            response.put("attestation", options.attestation());
+
+            ObjectNode authenticatorSelection = objectMapper.createObjectNode();
+            if (options.authenticatorAttachment() != null) {
+                authenticatorSelection.put("authenticatorAttachment", options.authenticatorAttachment());
+            }
+            authenticatorSelection.put("residentKey", options.residentKey());
+            authenticatorSelection.put("userVerification", options.userVerification());
+            authenticatorSelection.put("requireResidentKey", "required".equals(options.residentKey()));
+            response.set("authenticatorSelection", authenticatorSelection);
+
+            ArrayNode pubKeyCredParams = objectMapper.createArrayNode();
+            // ES256 (most common)
+            ObjectNode es256 = objectMapper.createObjectNode();
+            es256.put("type", "public-key");
+            es256.put("alg", -7);
+            pubKeyCredParams.add(es256);
+            // RS256
+            ObjectNode rs256 = objectMapper.createObjectNode();
+            rs256.put("type", "public-key");
+            rs256.put("alg", -257);
+            pubKeyCredParams.add(rs256);
+            response.set("pubKeyCredParams", pubKeyCredParams);
+
+            if (!options.excludeCredentials().isEmpty()) {
+                ArrayNode excludeCredentials = objectMapper.createArrayNode();
+                for (String credId : options.excludeCredentials()) {
+                    ObjectNode cred = objectMapper.createObjectNode();
+                    cred.put("type", "public-key");
+                    cred.put("id", credId);
+                    excludeCredentials.add(cred);
+                }
+                response.set("excludeCredentials", excludeCredentials);
+            }
+
+            return ResponseEntity.ok(response);
+
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse("limit_reached", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse("server_error", "Failed to generate registration options"));
+        }
+    }
+
+    /**
+     * Complete passkey registration.
+     * Called after WebAuthn ceremony completes in browser.
+     */
+    @PostMapping("/register/complete")
+    public ResponseEntity<ObjectNode> completeRegistration(
+            @Valid @RequestBody PasskeyRegisterCompleteRequest request) {
+        try {
+            RegistrationResult result = passkeyService.completeRegistration(
+                request.challengeId(),
+                request.clientDataJSON(),
+                request.attestationObject(),
+                request.transports(),
+                request.displayName()
+            );
+
+            ObjectNode response = objectMapper.createObjectNode();
+            response.put("success", result.success());
+
+            if (result.success()) {
+                response.put("passkeyId", result.passkeyId());
+            } else {
+                response.put("error", result.error());
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+            }
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse("server_error", "Failed to complete registration"));
+        }
+    }
+
+    /**
+     * Generate authentication options for passkey login.
+     * Called when user wants to authenticate with passkey.
+     */
+    @PostMapping("/authenticate/options")
+    public ResponseEntity<ObjectNode> getAuthenticationOptions(
+            @Valid @RequestBody PasskeyAuthenticateOptionsRequest request) {
+        try {
+            AuthenticationOptionsResponse options = passkeyService.generateAuthenticationOptions(
+                request.loginId()
+            );
+
+            ObjectNode response = objectMapper.createObjectNode();
+            response.put("challengeId", options.challengeId());
+            response.put("challenge", options.challenge());
+            response.put("rpId", options.rpId());
+            response.put("timeout", options.timeout());
+            response.put("userVerification", options.userVerification());
+
+            if (!options.allowCredentials().isEmpty()) {
+                ArrayNode allowCredentials = objectMapper.createArrayNode();
+                for (AllowedCredential cred : options.allowCredentials()) {
+                    ObjectNode credNode = objectMapper.createObjectNode();
+                    credNode.put("type", "public-key");
+                    credNode.put("id", cred.id());
+                    if (cred.transports() != null && !cred.transports().isEmpty()) {
+                        ArrayNode transports = objectMapper.createArrayNode();
+                        cred.transports().forEach(transports::add);
+                        credNode.set("transports", transports);
+                    }
+                    allowCredentials.add(credNode);
+                }
+                response.set("allowCredentials", allowCredentials);
+            }
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse("server_error", "Failed to generate authentication options"));
+        }
+    }
+
+    /**
+     * Complete passkey authentication.
+     * Called after WebAuthn ceremony completes in browser.
+     */
+    @PostMapping("/authenticate/complete")
+    public ResponseEntity<ObjectNode> completeAuthentication(
+            @Valid @RequestBody PasskeyAuthenticateCompleteRequest request) {
+        try {
+            AuthenticationResult result = passkeyService.completeAuthentication(
+                request.challengeId(),
+                request.credentialId(),
+                request.clientDataJSON(),
+                request.authenticatorData(),
+                request.signature(),
+                request.userHandle()
+            );
+
+            ObjectNode response = objectMapper.createObjectNode();
+            response.put("success", result.success());
+
+            if (result.success()) {
+                response.put("userId", result.userId());
+                response.put("loginId", result.loginId());
+                response.put("email", result.email());
+                response.put("profileId", result.profileId());
+                response.put("userVerification", result.userVerification());
+            } else {
+                response.put("error", result.error());
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+            }
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse("server_error", "Failed to complete authentication"));
+        }
+    }
+
+    /**
+     * List passkeys for a user.
+     */
+    @PostMapping("/list")
+    public ResponseEntity<ObjectNode> listPasskeys(
+            @Valid @RequestBody PasskeyListRequest request) {
+        try {
+            User user = userRepository.findByLoginId(request.loginId())
+                .orElse(null);
+
+            if (user == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(errorResponse("user_not_found", "User not found"));
+            }
+
+            List<PasskeySummary> passkeys = passkeyService.listPasskeys(user.id());
+
+            ObjectNode response = objectMapper.createObjectNode();
+            ArrayNode passkeysArray = objectMapper.createArrayNode();
+
+            for (PasskeySummary pk : passkeys) {
+                ObjectNode pkNode = objectMapper.createObjectNode();
+                pkNode.put("id", pk.id());
+                pkNode.put("displayName", pk.displayName());
+                pkNode.put("createdAt", pk.createdAt().toString());
+                if (pk.lastUsedAt() != null) {
+                    pkNode.put("lastUsedAt", pk.lastUsedAt().toString());
+                }
+                pkNode.put("userVerification", pk.userVerification());
+                pkNode.put("backedUp", pk.backedUp());
+                passkeysArray.add(pkNode);
+            }
+
+            response.set("passkeys", passkeysArray);
+            response.put("count", passkeys.size());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse("server_error", "Failed to list passkeys"));
+        }
+    }
+
+    /**
+     * Delete a passkey.
+     */
+    @PostMapping("/delete")
+    public ResponseEntity<ObjectNode> deletePasskey(
+            @Valid @RequestBody PasskeyDeleteRequest request) {
+        try {
+            User user = userRepository.findByLoginId(request.loginId())
+                .orElse(null);
+
+            if (user == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(errorResponse("user_not_found", "User not found"));
+            }
+
+            boolean deleted = passkeyService.deletePasskey(user.id(), request.passkeyId());
+
+            ObjectNode response = objectMapper.createObjectNode();
+            response.put("success", deleted);
+
+            if (!deleted) {
+                response.put("error", "Passkey not found");
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+            }
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse("server_error", "Failed to delete passkey"));
+        }
+    }
+
+    /**
+     * Update passkey display name.
+     */
+    @PostMapping("/update")
+    public ResponseEntity<ObjectNode> updatePasskey(
+            @Valid @RequestBody PasskeyUpdateRequest request) {
+        try {
+            User user = userRepository.findByLoginId(request.loginId())
+                .orElse(null);
+
+            if (user == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(errorResponse("user_not_found", "User not found"));
+            }
+
+            boolean updated = passkeyService.updatePasskeyName(
+                user.id(),
+                request.passkeyId(),
+                request.displayName()
+            );
+
+            ObjectNode response = objectMapper.createObjectNode();
+            response.put("success", updated);
+
+            if (!updated) {
+                response.put("error", "Passkey not found");
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+            }
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse("server_error", "Failed to update passkey"));
+        }
+    }
+
+    private ObjectNode errorResponse(String error, String message) {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("error", error);
+        response.put("message", message);
+        return response;
+    }
+}

--- a/application/src/main/java/com/knight/application/rest/login/dto/PasskeyAuthenticateCompleteRequest.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/PasskeyAuthenticateCompleteRequest.java
@@ -1,0 +1,22 @@
+package com.knight.application.rest.login.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasskeyAuthenticateCompleteRequest(
+    @NotBlank(message = "Challenge ID is required")
+    String challengeId,
+
+    @NotBlank(message = "Credential ID is required")
+    String credentialId,
+
+    @NotBlank(message = "Client data JSON is required")
+    String clientDataJSON,
+
+    @NotBlank(message = "Authenticator data is required")
+    String authenticatorData,
+
+    @NotBlank(message = "Signature is required")
+    String signature,
+
+    String userHandle
+) {}

--- a/application/src/main/java/com/knight/application/rest/login/dto/PasskeyAuthenticateOptionsRequest.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/PasskeyAuthenticateOptionsRequest.java
@@ -1,0 +1,5 @@
+package com.knight.application.rest.login.dto;
+
+public record PasskeyAuthenticateOptionsRequest(
+    String loginId  // Optional - can be null for discoverable credentials
+) {}

--- a/application/src/main/java/com/knight/application/rest/login/dto/PasskeyDeleteRequest.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/PasskeyDeleteRequest.java
@@ -1,0 +1,11 @@
+package com.knight.application.rest.login.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasskeyDeleteRequest(
+    @NotBlank(message = "Login ID is required")
+    String loginId,
+
+    @NotBlank(message = "Passkey ID is required")
+    String passkeyId
+) {}

--- a/application/src/main/java/com/knight/application/rest/login/dto/PasskeyListRequest.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/PasskeyListRequest.java
@@ -1,0 +1,8 @@
+package com.knight.application.rest.login.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasskeyListRequest(
+    @NotBlank(message = "Login ID is required")
+    String loginId
+) {}

--- a/application/src/main/java/com/knight/application/rest/login/dto/PasskeyRegisterCompleteRequest.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/PasskeyRegisterCompleteRequest.java
@@ -1,0 +1,18 @@
+package com.knight.application.rest.login.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasskeyRegisterCompleteRequest(
+    @NotBlank(message = "Challenge ID is required")
+    String challengeId,
+
+    @NotBlank(message = "Client data JSON is required")
+    String clientDataJSON,
+
+    @NotBlank(message = "Attestation object is required")
+    String attestationObject,
+
+    String[] transports,
+
+    String displayName
+) {}

--- a/application/src/main/java/com/knight/application/rest/login/dto/PasskeyRegisterOptionsRequest.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/PasskeyRegisterOptionsRequest.java
@@ -1,0 +1,8 @@
+package com.knight.application.rest.login.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasskeyRegisterOptionsRequest(
+    @NotBlank(message = "Login ID is required")
+    String loginId
+) {}

--- a/application/src/main/java/com/knight/application/rest/login/dto/PasskeyUpdateRequest.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/PasskeyUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.knight.application.rest.login.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasskeyUpdateRequest(
+    @NotBlank(message = "Login ID is required")
+    String loginId,
+
+    @NotBlank(message = "Passkey ID is required")
+    String passkeyId,
+
+    @NotBlank(message = "Display name is required")
+    String displayName
+) {}

--- a/application/src/main/java/com/knight/application/rest/login/dto/UserCheckResponse.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/UserCheckResponse.java
@@ -30,6 +30,12 @@ public record UserCheckResponse(
     @JsonProperty("email_verified")
     boolean emailVerified,
 
+    @JsonProperty("passkey_enrolled")
+    boolean passkeyEnrolled,
+
+    @JsonProperty("passkey_offered")
+    boolean passkeyOffered,
+
     @JsonProperty("mfa_factors")
     List<String> mfaFactors,
 
@@ -42,13 +48,14 @@ public record UserCheckResponse(
     }
 
     public static UserCheckResponse notFound() {
-        return new UserCheckResponse(false, null, null, null, false, false, false, false, false, List.of(), List.of());
+        return new UserCheckResponse(false, null, null, null, false, false, false, false, false, false, false, List.of(), List.of());
     }
 
     public static UserCheckResponse found(String userId, String email, ClientType clientType,
                                           boolean mfaEnrolled, boolean hasMfa, boolean hasPassword,
-                                          boolean onboardingComplete, boolean emailVerified) {
+                                          boolean onboardingComplete, boolean emailVerified,
+                                          boolean passkeyEnrolled, boolean passkeyOffered) {
         return new UserCheckResponse(true, userId, email, clientType, mfaEnrolled, hasMfa, hasPassword,
-                                     onboardingComplete, emailVerified, List.of(), List.of());
+                                     onboardingComplete, emailVerified, passkeyEnrolled, passkeyOffered, List.of(), List.of());
     }
 }

--- a/application/src/main/java/com/knight/application/service/passkey/AllowedCredential.java
+++ b/application/src/main/java/com/knight/application/service/passkey/AllowedCredential.java
@@ -1,0 +1,11 @@
+package com.knight.application.service.passkey;
+
+import java.util.List;
+
+/**
+ * Allowed credential for WebAuthn authentication.
+ */
+public record AllowedCredential(
+    String id,
+    List<String> transports
+) {}

--- a/application/src/main/java/com/knight/application/service/passkey/AuthenticationOptionsResponse.java
+++ b/application/src/main/java/com/knight/application/service/passkey/AuthenticationOptionsResponse.java
@@ -1,0 +1,15 @@
+package com.knight.application.service.passkey;
+
+import java.util.List;
+
+/**
+ * Response containing WebAuthn authentication options.
+ */
+public record AuthenticationOptionsResponse(
+    String challengeId,
+    String challenge,
+    String rpId,
+    long timeout,
+    String userVerification,
+    List<AllowedCredential> allowCredentials
+) {}

--- a/application/src/main/java/com/knight/application/service/passkey/AuthenticationResult.java
+++ b/application/src/main/java/com/knight/application/service/passkey/AuthenticationResult.java
@@ -1,0 +1,23 @@
+package com.knight.application.service.passkey;
+
+/**
+ * Result of passkey authentication.
+ */
+public record AuthenticationResult(
+    boolean success,
+    String userId,
+    String loginId,
+    String email,
+    String profileId,
+    boolean userVerification,
+    String error
+) {
+    public static AuthenticationResult success(String userId, String loginId, String email,
+                                                String profileId, boolean userVerification) {
+        return new AuthenticationResult(true, userId, loginId, email, profileId, userVerification, null);
+    }
+
+    public static AuthenticationResult failure(String error) {
+        return new AuthenticationResult(false, null, null, null, null, false, error);
+    }
+}

--- a/application/src/main/java/com/knight/application/service/passkey/PasskeyProperties.java
+++ b/application/src/main/java/com/knight/application/service/passkey/PasskeyProperties.java
@@ -1,0 +1,56 @@
+package com.knight.application.service.passkey;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "passkey")
+public class PasskeyProperties {
+
+    /**
+     * Relying Party ID - typically the domain name.
+     * Must match the domain where the passkey is used.
+     */
+    private String rpId = "localhost";
+
+    /**
+     * Relying Party name - displayed to users during registration.
+     */
+    private String rpName = "Knight Platform";
+
+    /**
+     * Origins allowed for WebAuthn ceremonies.
+     * Should include the full origin (e.g., https://login.example.com)
+     */
+    private String[] allowedOrigins = {"http://localhost:8001"};
+
+    /**
+     * Timeout for registration/authentication ceremonies in milliseconds.
+     */
+    private long timeout = 60000;
+
+    /**
+     * Whether to require user verification (biometric/PIN).
+     * Options: required, preferred, discouraged
+     */
+    private String userVerification = "preferred";
+
+    /**
+     * Whether to require resident keys (discoverable credentials).
+     * Options: required, preferred, discouraged
+     */
+    private String residentKey = "preferred";
+
+    /**
+     * Attestation conveyance preference.
+     * Options: none, indirect, direct, enterprise
+     */
+    private String attestation = "none";
+
+    /**
+     * Maximum number of passkeys per user.
+     */
+    private int maxPasskeysPerUser = 10;
+}

--- a/application/src/main/java/com/knight/application/service/passkey/PasskeyService.java
+++ b/application/src/main/java/com/knight/application/service/passkey/PasskeyService.java
@@ -1,0 +1,490 @@
+package com.knight.application.service.passkey;
+
+import com.knight.domain.users.aggregate.Passkey;
+import com.knight.domain.users.aggregate.User;
+import com.knight.domain.users.repository.PasskeyRepository;
+import com.knight.domain.users.repository.UserRepository;
+import com.knight.platform.sharedkernel.UserId;
+import com.webauthn4j.WebAuthnManager;
+import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.authenticator.AuthenticatorImpl;
+import com.webauthn4j.converter.AttestationObjectConverter;
+import com.webauthn4j.converter.CollectedClientDataConverter;
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.*;
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
+import com.webauthn4j.data.client.Origin;
+import com.webauthn4j.data.client.challenge.Challenge;
+import com.webauthn4j.data.client.challenge.DefaultChallenge;
+import com.webauthn4j.server.ServerProperty;
+import com.webauthn4j.verifier.exception.VerificationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Service for WebAuthn/Passkey operations.
+ * Handles registration and authentication ceremonies using WebAuthn4j.
+ */
+@Service
+public class PasskeyService {
+
+    private static final Logger log = LoggerFactory.getLogger(PasskeyService.class);
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final PasskeyProperties properties;
+    private final PasskeyRepository passkeyRepository;
+    private final UserRepository userRepository;
+    private final WebAuthnManager webAuthnManager;
+    private final ObjectConverter objectConverter;
+
+    // In-memory challenge storage (should be Redis in production)
+    private final Map<String, ChallengeRecord> challengeStore = new ConcurrentHashMap<>();
+
+    private record ChallengeRecord(
+        Challenge challenge,
+        UserId userId,
+        CeremonyType ceremonyType,
+        long expiresAt
+    ) {}
+
+    public enum CeremonyType {
+        REGISTRATION,
+        AUTHENTICATION
+    }
+
+    public PasskeyService(
+            PasskeyProperties properties,
+            PasskeyRepository passkeyRepository,
+            UserRepository userRepository) {
+        this.properties = properties;
+        this.passkeyRepository = passkeyRepository;
+        this.userRepository = userRepository;
+        this.objectConverter = new ObjectConverter();
+        this.webAuthnManager = WebAuthnManager.createNonStrictWebAuthnManager();
+    }
+
+    /**
+     * Generate registration options for passkey enrollment.
+     */
+    public RegistrationOptionsResponse generateRegistrationOptions(UserId userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+
+        // Check max passkeys limit
+        int existingCount = passkeyRepository.countByUserId(userId);
+        if (existingCount >= properties.getMaxPasskeysPerUser()) {
+            throw new IllegalStateException("Maximum passkeys limit reached");
+        }
+
+        // Generate challenge
+        byte[] challengeBytes = new byte[32];
+        SECURE_RANDOM.nextBytes(challengeBytes);
+        Challenge challenge = new DefaultChallenge(challengeBytes);
+
+        // Store challenge for verification
+        String challengeId = UUID.randomUUID().toString();
+        challengeStore.put(challengeId, new ChallengeRecord(
+            challenge,
+            userId,
+            CeremonyType.REGISTRATION,
+            System.currentTimeMillis() + properties.getTimeout()
+        ));
+
+        // Get existing credential IDs to exclude
+        List<String> excludeCredentials = passkeyRepository.findByUserId(userId)
+            .stream()
+            .map(Passkey::credentialId)
+            .collect(Collectors.toList());
+
+        return new RegistrationOptionsResponse(
+            challengeId,
+            Base64.getUrlEncoder().withoutPadding().encodeToString(challengeBytes),
+            properties.getRpId(),
+            properties.getRpName(),
+            user.id().id(),
+            user.loginId(),
+            user.email(),
+            properties.getTimeout(),
+            properties.getAttestation(),
+            parseAuthenticatorAttachment(),
+            properties.getResidentKey(),
+            properties.getUserVerification(),
+            excludeCredentials
+        );
+    }
+
+    /**
+     * Complete passkey registration.
+     */
+    @Transactional
+    public RegistrationResult completeRegistration(
+            String challengeId,
+            String clientDataJSON,
+            String attestationObject,
+            String[] transports,
+            String displayName) {
+
+        // Retrieve and validate challenge
+        ChallengeRecord record = challengeStore.remove(challengeId);
+        if (record == null) {
+            return RegistrationResult.failure("Invalid or expired challenge");
+        }
+        if (System.currentTimeMillis() > record.expiresAt()) {
+            return RegistrationResult.failure("Challenge expired");
+        }
+        if (record.ceremonyType() != CeremonyType.REGISTRATION) {
+            return RegistrationResult.failure("Invalid ceremony type");
+        }
+
+        try {
+            // Decode inputs
+            byte[] clientDataBytes = Base64.getUrlDecoder().decode(clientDataJSON);
+            byte[] attestationBytes = Base64.getUrlDecoder().decode(attestationObject);
+
+            // Build server property
+            Set<Origin> origins = Arrays.stream(properties.getAllowedOrigins())
+                .map(Origin::new)
+                .collect(Collectors.toSet());
+
+            ServerProperty serverProperty = new ServerProperty(
+                origins,
+                properties.getRpId(),
+                record.challenge(),
+                null  // No token binding
+            );
+
+            // Parse registration request
+            RegistrationRequest registrationRequest = new RegistrationRequest(
+                attestationBytes,
+                clientDataBytes
+            );
+
+            // Validate registration
+            RegistrationParameters registrationParameters = new RegistrationParameters(
+                serverProperty,
+                null,  // pubKeyCredParams - null means accept all
+                parseUserVerificationRequirement().equals(UserVerificationRequirement.REQUIRED)
+            );
+
+            RegistrationData registrationData = webAuthnManager.parse(registrationRequest);
+            webAuthnManager.validate(registrationData, registrationParameters);
+
+            // Extract credential data
+            AttestationObject attObj = registrationData.getAttestationObject();
+            AttestedCredentialData credData = attObj.getAuthenticatorData().getAttestedCredentialData();
+
+            if (credData == null) {
+                return RegistrationResult.failure("No credential data in attestation");
+            }
+
+            String credentialId = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(credData.getCredentialId());
+            String publicKey = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(objectConverter.getCborConverter().writeValueAsBytes(credData.getCOSEKey()));
+            String aaguid = credData.getAaguid().toString();
+            long signCount = attObj.getAuthenticatorData().getSignCount();
+            boolean userVerification = attObj.getAuthenticatorData().isFlagUV();
+            boolean backupEligible = attObj.getAuthenticatorData().isFlagBE();
+            boolean backupState = attObj.getAuthenticatorData().isFlagBS();
+
+            // Check for duplicate credential
+            if (passkeyRepository.findByCredentialId(credentialId).isPresent()) {
+                return RegistrationResult.failure("Credential already registered");
+            }
+
+            // Create and save passkey
+            Passkey passkey = Passkey.create(
+                record.userId(),
+                credentialId,
+                publicKey,
+                aaguid,
+                displayName != null ? displayName : "Passkey",
+                signCount,
+                userVerification,
+                backupEligible,
+                backupState,
+                transports
+            );
+            passkeyRepository.save(passkey);
+
+            // Update user passkey status
+            User user = userRepository.findById(record.userId())
+                .orElseThrow(() -> new IllegalStateException("User not found"));
+            user.enrollPasskey(userVerification);
+            userRepository.save(user);
+
+            log.info("Passkey registered for user: {}, credentialId: {}",
+                record.userId(), credentialId.substring(0, 20) + "...");
+
+            return RegistrationResult.success(passkey.id().id());
+
+        } catch (VerificationException e) {
+            log.warn("Passkey registration validation failed: {}", e.getMessage());
+            return RegistrationResult.failure("Validation failed: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("Passkey registration error", e);
+            return RegistrationResult.failure("Registration failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Generate authentication options for passkey login.
+     */
+    public AuthenticationOptionsResponse generateAuthenticationOptions(String loginId) {
+        // Find user by login ID
+        Optional<User> userOpt = userRepository.findByLoginId(loginId);
+
+        // Generate challenge
+        byte[] challengeBytes = new byte[32];
+        SECURE_RANDOM.nextBytes(challengeBytes);
+        Challenge challenge = new DefaultChallenge(challengeBytes);
+
+        String challengeId = UUID.randomUUID().toString();
+        UserId userId = userOpt.map(User::id).orElse(null);
+
+        challengeStore.put(challengeId, new ChallengeRecord(
+            challenge,
+            userId,
+            CeremonyType.AUTHENTICATION,
+            System.currentTimeMillis() + properties.getTimeout()
+        ));
+
+        // Get allowed credentials for this user (if found)
+        List<AllowedCredential> allowCredentials = new ArrayList<>();
+        if (userOpt.isPresent()) {
+            allowCredentials = passkeyRepository.findByUserId(userOpt.get().id())
+                .stream()
+                .map(p -> new AllowedCredential(
+                    p.credentialId(),
+                    Arrays.asList(p.transports())
+                ))
+                .collect(Collectors.toList());
+        }
+
+        return new AuthenticationOptionsResponse(
+            challengeId,
+            Base64.getUrlEncoder().withoutPadding().encodeToString(challengeBytes),
+            properties.getRpId(),
+            properties.getTimeout(),
+            properties.getUserVerification(),
+            allowCredentials
+        );
+    }
+
+    /**
+     * Complete passkey authentication.
+     */
+    @Transactional
+    public AuthenticationResult completeAuthentication(
+            String challengeId,
+            String credentialId,
+            String clientDataJSON,
+            String authenticatorData,
+            String signature,
+            String userHandle) {
+
+        // Retrieve and validate challenge
+        ChallengeRecord record = challengeStore.remove(challengeId);
+        if (record == null) {
+            return AuthenticationResult.failure("Invalid or expired challenge");
+        }
+        if (System.currentTimeMillis() > record.expiresAt()) {
+            return AuthenticationResult.failure("Challenge expired");
+        }
+        if (record.ceremonyType() != CeremonyType.AUTHENTICATION) {
+            return AuthenticationResult.failure("Invalid ceremony type");
+        }
+
+        try {
+            // Find the passkey
+            Optional<Passkey> passkeyOpt = passkeyRepository.findByCredentialId(credentialId);
+            if (passkeyOpt.isEmpty()) {
+                return AuthenticationResult.failure("Credential not found");
+            }
+            Passkey passkey = passkeyOpt.get();
+
+            // Get the user
+            User user = userRepository.findById(passkey.userId())
+                .orElseThrow(() -> new IllegalStateException("User not found for passkey"));
+
+            // Check user status
+            if (user.status() == User.Status.LOCKED) {
+                return AuthenticationResult.failure("Account is locked");
+            }
+            if (user.status() == User.Status.DEACTIVATED) {
+                return AuthenticationResult.failure("Account is deactivated");
+            }
+
+            // Decode inputs
+            byte[] credentialIdBytes = Base64.getUrlDecoder().decode(credentialId);
+            byte[] clientDataBytes = Base64.getUrlDecoder().decode(clientDataJSON);
+            byte[] authenticatorDataBytes = Base64.getUrlDecoder().decode(authenticatorData);
+            byte[] signatureBytes = Base64.getUrlDecoder().decode(signature);
+
+            // Build server property
+            Set<Origin> origins = Arrays.stream(properties.getAllowedOrigins())
+                .map(Origin::new)
+                .collect(Collectors.toSet());
+
+            ServerProperty serverProperty = new ServerProperty(
+                origins,
+                properties.getRpId(),
+                record.challenge(),
+                null
+            );
+
+            // Build authenticator for validation
+            byte[] publicKeyBytes = Base64.getUrlDecoder().decode(passkey.publicKey());
+            Authenticator authenticator = new AuthenticatorImpl(
+                null,  // attestedCredentialData not needed for assertion
+                null,  // attestationStatement
+                passkey.signCount()
+            );
+
+            // Parse authentication request
+            AuthenticationRequest authRequest = new AuthenticationRequest(
+                credentialIdBytes,
+                null,  // userHandle
+                authenticatorDataBytes,
+                clientDataBytes,
+                null,  // clientExtensionsJSON
+                signatureBytes
+            );
+
+            // Build parameters
+            AuthenticationParameters authParams = new AuthenticationParameters(
+                serverProperty,
+                authenticator,
+                List.of(credentialIdBytes),
+                parseUserVerificationRequirement().equals(UserVerificationRequirement.REQUIRED)
+            );
+
+            // Parse and get authenticator data for sign count
+            AuthenticationData authData = webAuthnManager.parse(authRequest);
+
+            // Validate authentication
+            webAuthnManager.validate(authData, authParams);
+
+            // Update sign count
+            long newSignCount = authData.getAuthenticatorData().getSignCount();
+            if (newSignCount > 0) {
+                passkey.updateSignCount(newSignCount);
+                passkeyRepository.save(passkey);
+            } else {
+                passkey.recordUsage();
+                passkeyRepository.save(passkey);
+            }
+
+            // Record login
+            user.recordLogin();
+            userRepository.save(user);
+
+            log.info("Passkey authentication successful for user: {}", user.loginId());
+
+            return AuthenticationResult.success(
+                user.id().id(),
+                user.loginId(),
+                user.email(),
+                user.profileId().urn(),
+                passkey.userVerification()
+            );
+
+        } catch (VerificationException e) {
+            log.warn("Passkey authentication validation failed: {}", e.getMessage());
+            return AuthenticationResult.failure("Validation failed: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("Passkey authentication error", e);
+            return AuthenticationResult.failure("Authentication failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * List passkeys for a user.
+     */
+    public List<PasskeySummary> listPasskeys(UserId userId) {
+        return passkeyRepository.findByUserId(userId)
+            .stream()
+            .map(p -> new PasskeySummary(
+                p.id().id(),
+                p.displayName(),
+                p.createdAt(),
+                p.lastUsedAt(),
+                p.userVerification(),
+                p.backupState()
+            ))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Delete a passkey.
+     */
+    @Transactional
+    public boolean deletePasskey(UserId userId, String passkeyId) {
+        List<Passkey> userPasskeys = passkeyRepository.findByUserId(userId);
+
+        Optional<Passkey> toDelete = userPasskeys.stream()
+            .filter(p -> p.id().id().equals(passkeyId))
+            .findFirst();
+
+        if (toDelete.isEmpty()) {
+            return false;
+        }
+
+        passkeyRepository.deleteById(toDelete.get().id());
+
+        // Update user status if no more passkeys
+        if (userPasskeys.size() == 1) {
+            User user = userRepository.findById(userId).orElse(null);
+            if (user != null) {
+                user.unenrollPasskey();
+                userRepository.save(user);
+            }
+        }
+
+        log.info("Passkey deleted for user: {}, passkeyId: {}", userId, passkeyId);
+        return true;
+    }
+
+    /**
+     * Update passkey display name.
+     */
+    @Transactional
+    public boolean updatePasskeyName(UserId userId, String passkeyId, String displayName) {
+        return passkeyRepository.findByUserId(userId).stream()
+            .filter(p -> p.id().id().equals(passkeyId))
+            .findFirst()
+            .map(p -> {
+                p.updateDisplayName(displayName);
+                passkeyRepository.save(p);
+                return true;
+            })
+            .orElse(false);
+    }
+
+    private String parseAuthenticatorAttachment() {
+        // Return null to allow any authenticator type (platform or cross-platform)
+        return null;
+    }
+
+    private UserVerificationRequirement parseUserVerificationRequirement() {
+        return switch (properties.getUserVerification().toLowerCase()) {
+            case "required" -> UserVerificationRequirement.REQUIRED;
+            case "discouraged" -> UserVerificationRequirement.DISCOURAGED;
+            default -> UserVerificationRequirement.PREFERRED;
+        };
+    }
+
+    // Cleanup expired challenges (should be called periodically)
+    public void cleanupExpiredChallenges() {
+        long now = System.currentTimeMillis();
+        challengeStore.entrySet().removeIf(e -> e.getValue().expiresAt() < now);
+    }
+}

--- a/application/src/main/java/com/knight/application/service/passkey/PasskeySummary.java
+++ b/application/src/main/java/com/knight/application/service/passkey/PasskeySummary.java
@@ -1,0 +1,15 @@
+package com.knight.application.service.passkey;
+
+import java.time.Instant;
+
+/**
+ * Summary of a registered passkey for display purposes.
+ */
+public record PasskeySummary(
+    String id,
+    String displayName,
+    Instant createdAt,
+    Instant lastUsedAt,
+    boolean userVerification,
+    boolean backedUp
+) {}

--- a/application/src/main/java/com/knight/application/service/passkey/RegistrationOptionsResponse.java
+++ b/application/src/main/java/com/knight/application/service/passkey/RegistrationOptionsResponse.java
@@ -1,0 +1,22 @@
+package com.knight.application.service.passkey;
+
+import java.util.List;
+
+/**
+ * Response containing WebAuthn registration options.
+ */
+public record RegistrationOptionsResponse(
+    String challengeId,
+    String challenge,
+    String rpId,
+    String rpName,
+    String userId,
+    String userName,
+    String userDisplayName,
+    long timeout,
+    String attestation,
+    String authenticatorAttachment,
+    String residentKey,
+    String userVerification,
+    List<String> excludeCredentials
+) {}

--- a/application/src/main/java/com/knight/application/service/passkey/RegistrationResult.java
+++ b/application/src/main/java/com/knight/application/service/passkey/RegistrationResult.java
@@ -1,0 +1,18 @@
+package com.knight.application.service.passkey;
+
+/**
+ * Result of passkey registration.
+ */
+public record RegistrationResult(
+    boolean success,
+    String passkeyId,
+    String error
+) {
+    public static RegistrationResult success(String passkeyId) {
+        return new RegistrationResult(true, passkeyId, null);
+    }
+
+    public static RegistrationResult failure(String error) {
+        return new RegistrationResult(false, null, error);
+    }
+}

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -152,3 +152,14 @@ otp:
   rate-limit-window-seconds: ${OTP_RATE_LIMIT_WINDOW:60}
   rate-limit-max-requests: ${OTP_RATE_LIMIT_MAX:3}
   resend-cooldown-seconds: ${OTP_RESEND_COOLDOWN:30}
+
+# Passkey/WebAuthn Configuration
+passkey:
+  rp-id: ${PASSKEY_RP_ID:localhost}
+  rp-name: ${PASSKEY_RP_NAME:Knight Platform}
+  allowed-origins: ${PASSKEY_ALLOWED_ORIGINS:http://localhost:8001}
+  timeout: ${PASSKEY_TIMEOUT:60000}
+  user-verification: ${PASSKEY_USER_VERIFICATION:preferred}
+  resident-key: ${PASSKEY_RESIDENT_KEY:preferred}
+  attestation: ${PASSKEY_ATTESTATION:none}
+  max-passkeys-per-user: ${PASSKEY_MAX_PER_USER:10}

--- a/application/src/main/resources/db/migration/V6__passkeys.sql
+++ b/application/src/main/resources/db/migration/V6__passkeys.sql
@@ -1,0 +1,33 @@
+-- =====================================================
+-- PASSKEY/WEBAUTHN SUPPORT
+-- =====================================================
+
+-- Add passkey tracking fields to users table
+ALTER TABLE users ADD passkey_offered BIT NOT NULL DEFAULT 0;
+ALTER TABLE users ADD passkey_enrolled BIT NOT NULL DEFAULT 0;
+ALTER TABLE users ADD passkey_has_uv BIT NOT NULL DEFAULT 0;
+
+-- Passkeys table for WebAuthn credentials
+CREATE TABLE passkeys (
+    passkey_id UNIQUEIDENTIFIER PRIMARY KEY,
+    user_id UNIQUEIDENTIFIER NOT NULL,
+    credential_id VARCHAR(1024) NOT NULL UNIQUE,  -- Base64URL encoded, can be long
+    public_key VARCHAR(2048) NOT NULL,             -- Base64URL encoded COSE public key
+    aaguid VARCHAR(36),                            -- Authenticator Attestation GUID
+    display_name NVARCHAR(255) NOT NULL,           -- User-friendly name
+    sign_count BIGINT NOT NULL DEFAULT 0,          -- Signature counter for replay detection
+    user_verification BIT NOT NULL DEFAULT 0,      -- Whether UV is supported
+    backup_eligible BIT NOT NULL DEFAULT 0,        -- Credential can be backed up (synced)
+    backup_state BIT NOT NULL DEFAULT 0,           -- Credential is currently backed up
+    transports VARCHAR(255),                       -- Comma-separated: usb,nfc,ble,internal,hybrid
+    last_used_at DATETIME2,
+    created_at DATETIME2 NOT NULL,
+    updated_at DATETIME2 NOT NULL,
+
+    CONSTRAINT FK_passkeys_user FOREIGN KEY (user_id)
+        REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_passkeys_user ON passkeys(user_id);
+CREATE INDEX idx_passkeys_credential_id ON passkeys(credential_id);
+CREATE INDEX idx_passkeys_last_used ON passkeys(last_used_at DESC);

--- a/client-login/conf.d/default.conf
+++ b/client-login/conf.d/default.conf
@@ -835,6 +835,259 @@ server {
         proxy_set_header Content-Type application/json;
     }
 
+    # ============================================
+    # Passkey/WebAuthn API Endpoints
+    # Local WebAuthn implementation for passkey enrollment and authentication
+    # ============================================
+
+    # Passkey - Get registration options (enrollment)
+    location /api/passkey/register/options {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/passkey/register/options;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # Passkey - Complete registration
+    location /api/passkey/register/complete {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/passkey/register/complete;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # Passkey - Get authentication options
+    location /api/passkey/authenticate/options {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/passkey/authenticate/options;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # Passkey - Complete authentication (creates session on success)
+    location /api/passkey/authenticate/complete {
+        content_by_lua_block {
+            -- CORS check
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            local api_proxy = require "api_proxy"
+            api_proxy.handle_passkey_authenticate()
+        }
+    }
+
+    # Passkey - List user's passkeys
+    location /api/passkey/list {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/passkey/list;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # Passkey - Delete a passkey
+    location /api/passkey/delete {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/passkey/delete;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # Passkey - Update passkey display name
+    location /api/passkey/update {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/passkey/update;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
     # Forgot password - send password reset email
     location /api/auth/forgot-password {
         content_by_lua_block {

--- a/client-login/login/index.html
+++ b/client-login/login/index.html
@@ -525,6 +525,126 @@
                 </div>
             </div>
 
+            <!-- Screen 16: Passkey Enrollment Offer -->
+            <div id="screen-passkey-offer" class="screen">
+                <div class="login-card-header">
+                    <h1>Faster sign in next time</h1>
+                    <p>Set up a passkey for quicker, more secure access</p>
+                </div>
+                <div class="login-card-body">
+                    <div id="passkey-offer-error" class="message message-error" style="display: none;"></div>
+
+                    <div style="text-align: center; padding: var(--spacing-lg) 0;">
+                        <div style="font-size: 4rem; margin-bottom: var(--spacing-md);">🔐</div>
+                        <p style="color: var(--gray-600); margin-bottom: var(--spacing-lg);">
+                            Passkeys use your device's biometrics (Face ID, fingerprint, or PIN) to sign you in - no password needed.
+                        </p>
+
+                        <ul style="text-align: left; list-style: none; padding: 0; margin: 0 0 var(--spacing-lg) 0;">
+                            <li style="padding: var(--spacing-sm) 0; color: var(--gray-700);">
+                                <span style="color: var(--color-success); margin-right: var(--spacing-sm);">✓</span>
+                                More secure than passwords
+                            </li>
+                            <li style="padding: var(--spacing-sm) 0; color: var(--gray-700);">
+                                <span style="color: var(--color-success); margin-right: var(--spacing-sm);">✓</span>
+                                Works across your devices
+                            </li>
+                            <li style="padding: var(--spacing-sm) 0; color: var(--gray-700);">
+                                <span style="color: var(--color-success); margin-right: var(--spacing-sm);">✓</span>
+                                Sign in with just a touch or glance
+                            </li>
+                        </ul>
+                    </div>
+
+                    <button type="button" id="passkey-offer-accept" class="btn btn-primary">
+                        <span class="btn-text">Set Up Passkey</span>
+                        <span class="spinner" style="display: none;"></span>
+                    </button>
+
+                    <div class="help-link" style="margin-top: var(--spacing-md);">
+                        <a href="#" id="passkey-offer-skip">Maybe later</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Screen 17: Passkey Registration In Progress -->
+            <div id="screen-passkey-register" class="screen">
+                <div class="login-card-header">
+                    <h1>Register your passkey</h1>
+                    <p>Follow the prompts on your device</p>
+                </div>
+                <div class="login-card-body">
+                    <div id="passkey-register-error" class="message message-error" style="display: none;"></div>
+
+                    <div style="text-align: center; padding: var(--spacing-xl) 0;">
+                        <div style="font-size: 4rem; margin-bottom: var(--spacing-lg);">🔐</div>
+                        <div class="spinner" style="display: inline-block; margin-bottom: var(--spacing-md);"></div>
+                        <p id="passkey-register-status" style="color: var(--gray-600);">
+                            Use your fingerprint, face, or PIN when prompted...
+                        </p>
+                    </div>
+
+                    <div class="help-link">
+                        <a href="#" id="passkey-register-cancel">Cancel</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Screen 18: Passkey Registration Success -->
+            <div id="screen-passkey-success" class="screen">
+                <div class="login-card-header">
+                    <h1>Passkey created!</h1>
+                    <p>You can now use it to sign in</p>
+                </div>
+                <div class="login-card-body" style="text-align: center;">
+                    <div style="font-size: 4rem; margin-bottom: var(--spacing-lg);">✓</div>
+                    <p style="color: var(--gray-600); margin-bottom: var(--spacing-lg);">
+                        Next time you sign in, you can use your passkey instead of a password.
+                    </p>
+
+                    <button type="button" id="passkey-success-continue" class="btn btn-primary">
+                        Continue
+                    </button>
+                </div>
+            </div>
+
+            <!-- Screen 19: Passkey Authentication -->
+            <div id="screen-passkey-auth" class="screen">
+                <div class="login-card-header">
+                    <h1>Sign in with passkey</h1>
+                    <p>Use your fingerprint, face, or PIN</p>
+                </div>
+                <div class="login-card-body">
+                    <div id="passkey-auth-error" class="message message-error" style="display: none;"></div>
+
+                    <div class="user-info" id="passkey-auth-user-info" style="background: var(--gray-50); padding: var(--spacing-md); border-radius: var(--radius-md); margin-bottom: var(--spacing-lg); display: flex; align-items: center; gap: var(--spacing-md);">
+                        <div style="width: 40px; height: 40px; background: var(--rbc-blue); border-radius: 50%; display: flex; align-items: center; justify-content: center; color: white; font-weight: 600;">
+                            <span id="passkey-auth-user-initial">U</span>
+                        </div>
+                        <div>
+                            <div id="passkey-auth-user-email" style="font-weight: 500; color: var(--gray-900);"></div>
+                            <a href="#" id="passkey-auth-change-user" style="font-size: 0.85rem; color: var(--rbc-blue);">Not you?</a>
+                        </div>
+                    </div>
+
+                    <div style="text-align: center; padding: var(--spacing-lg) 0;">
+                        <div style="font-size: 4rem; margin-bottom: var(--spacing-md);">🔐</div>
+                        <div class="spinner" id="passkey-auth-spinner" style="display: inline-block; margin-bottom: var(--spacing-md);"></div>
+                        <p id="passkey-auth-status" style="color: var(--gray-600);">
+                            Waiting for your device...
+                        </p>
+                    </div>
+
+                    <button type="button" id="passkey-auth-retry" class="btn btn-secondary" style="display: none;">
+                        Try Again
+                    </button>
+
+                    <div class="help-link" style="margin-top: var(--spacing-md);">
+                        <a href="#" id="passkey-auth-use-password">Use password instead</a>
+                    </div>
+                </div>
+            </div>
+
             <!-- Screen 14: Success -->
             <div id="screen-success" class="screen">
                 <div class="login-card-header">

--- a/docs/adr/001-local-webauthn-passkey-implementation.md
+++ b/docs/adr/001-local-webauthn-passkey-implementation.md
@@ -1,0 +1,149 @@
+# ADR-001: Local WebAuthn/Passkey Implementation
+
+**Status:** Proposed
+**Date:** 2026-01-05
+**Decision Makers:** TBD (requires security team review)
+
+## Context
+
+Issue #10 requires implementing passkey enrollment and authentication for indirect client users. Passkeys (WebAuthn/FIDO2) provide phishing-resistant, passwordless authentication that improves both security and user experience.
+
+Our system uses Auth0 as the identity provider for indirect client users, with a **custom login UI** (`client-login`) rather than Auth0's Universal Login. This architectural choice was made to provide a branded, integrated login experience.
+
+### Auth0 Passkey API Assessment
+
+We evaluated Auth0's passkey support for custom UI integration:
+
+| Auth0 Feature | Status | Limitation |
+|--------------|--------|------------|
+| Native Passkeys API | Early Access | Designed for native mobile apps (iOS/Android), not web custom UI |
+| Universal Login Passkeys | GA | Requires redirecting to Auth0-hosted login page |
+| MFA API WebAuthn enrollment | Roadmap (Q3 2024) | `/mfa/associate` does not support WebAuthn authenticator type |
+| MFA API WebAuthn challenge | Partial | Requires Actions + Universal Login redirect |
+| Management API | Available | Can store/retrieve credentials but no WebAuthn ceremony support |
+
+**Key Finding:** Auth0's passkey implementation is primarily designed for their Universal Login experience. Custom UI support via APIs is limited and still in early access/roadmap phases.
+
+## Decision
+
+We will implement WebAuthn/passkey functionality locally using the **WebAuthn4j** library, storing passkey credentials in our database rather than Auth0.
+
+### Implementation Approach
+
+1. **WebAuthn4j Library**: Use the FIDO2-conformant Java library (same library used by Keycloak and Spring Security)
+2. **Local Credential Storage**: Store passkey credentials in our `passkeys` table
+3. **User Aggregate Tracking**: Track passkey status (`passkeyOffered`, `passkeyEnrolled`, `passkeyHasUv`) on User aggregate
+4. **Relying Party**: Our application acts as the WebAuthn Relying Party
+5. **Step-up Authentication**: Use passkey verification for sensitive operations
+
+### Architecture
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  client-login   │────▶│ PasskeyController│────▶│  PasskeyService │
+│  (Browser)      │     │ (REST API)       │     │  (WebAuthn4j)   │
+└─────────────────┘     └──────────────────┘     └─────────────────┘
+        │                                                 │
+        │ navigator.credentials                           │
+        │ .create() / .get()                             ▼
+        ▼                                        ┌─────────────────┐
+┌─────────────────┐                              │  PasskeyRepo    │
+│  Authenticator  │                              │  (Database)     │
+│  (Platform/USB) │                              └─────────────────┘
+└─────────────────┘
+```
+
+### Data Model
+
+```sql
+CREATE TABLE passkeys (
+    passkey_id UNIQUEIDENTIFIER PRIMARY KEY,
+    user_id UNIQUEIDENTIFIER NOT NULL,
+    credential_id VARCHAR(1024) NOT NULL UNIQUE,
+    public_key VARCHAR(2048) NOT NULL,
+    aaguid VARCHAR(36),
+    display_name NVARCHAR(255) NOT NULL,
+    sign_count BIGINT NOT NULL DEFAULT 0,
+    user_verification BIT NOT NULL DEFAULT 0,
+    backup_eligible BIT NOT NULL DEFAULT 0,
+    backup_state BIT NOT NULL DEFAULT 0,
+    transports VARCHAR(255),
+    last_used_at DATETIME2,
+    created_at DATETIME2 NOT NULL,
+    updated_at DATETIME2 NOT NULL,
+    CONSTRAINT FK_passkeys_user FOREIGN KEY (user_id) REFERENCES users(user_id)
+);
+```
+
+## Alternatives Considered
+
+### 1. Redirect to Auth0 Universal Login for Passkeys
+- **Pros:** Uses Auth0's built-in passkey support, credentials managed by Auth0
+- **Cons:** Breaks custom UI experience, requires context switching, Auth0 manages credentials not us
+- **Rejected:** Inconsistent UX with rest of login flow
+
+### 2. Wait for Auth0 Native Passkeys API General Availability
+- **Pros:** Official Auth0 support, credentials in Auth0
+- **Cons:** Timeline uncertain, currently limited to mobile native apps
+- **Rejected:** Unacceptable delay for security feature
+
+### 3. Use Third-Party Passkey Service (e.g., Authsignal, Hanko)
+- **Pros:** Purpose-built passkey infrastructure
+- **Cons:** Additional vendor dependency, cost, data residency concerns
+- **Rejected:** Adds complexity and vendor lock-in
+
+### 4. Hybrid: Local WebAuthn + Sync to Auth0 Metadata
+- **Pros:** Best of both worlds
+- **Cons:** Complex sync logic, Auth0 metadata size limits
+- **Deferred:** Could be future enhancement
+
+## Consequences
+
+### Positive
+- Full control over passkey UX and enrollment flow
+- No dependency on Auth0 passkey roadmap
+- Consistent custom UI experience
+- Can implement step-up authentication for any operation
+- FIDO2-conformant implementation via WebAuthn4j
+
+### Negative
+- We own the passkey infrastructure and security
+- Passkeys not visible in Auth0 dashboard
+- Must maintain WebAuthn implementation ourselves
+- Credential recovery falls to us (not Auth0)
+
+### Security Considerations
+
+**Requires Security Team Review:**
+
+1. **Credential Storage**: Public keys stored in database (private keys never leave authenticator)
+2. **Replay Protection**: Sign count validation prevents cloned authenticator attacks
+3. **Origin Validation**: Strict RP ID and origin checking
+4. **User Verification**: Track and enforce UV requirements for sensitive operations
+5. **Attestation**: Consider whether to validate authenticator attestation
+6. **Transport Security**: All WebAuthn ceremonies over HTTPS
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Implementation vulnerabilities | Use well-tested WebAuthn4j library, security review |
+| Credential recovery | Implement secure recovery flow, keep password as backup |
+| Browser compatibility | Progressive enhancement, graceful fallback |
+| Authenticator loss | Support multiple passkeys per user, recovery codes |
+
+## Action Items
+
+- [ ] Security team review of this ADR
+- [ ] Penetration testing of WebAuthn implementation
+- [ ] Define attestation policy (none, indirect, direct)
+- [ ] Define credential recovery procedures
+- [ ] Document browser support matrix
+
+## References
+
+- [WebAuthn Specification](https://www.w3.org/TR/webauthn-2/)
+- [WebAuthn4j Documentation](https://webauthn4j.github.io/webauthn4j/en/)
+- [Auth0 Passkeys Documentation](https://auth0.com/docs/authenticate/database-connections/passkeys)
+- [Auth0 Native Passkeys API](https://auth0.com/docs/native-passkeys-api)
+- [FIDO Alliance Passkeys](https://fidoalliance.org/passkeys/)

--- a/domain/users/src/main/java/com/knight/domain/users/aggregate/Passkey.java
+++ b/domain/users/src/main/java/com/knight/domain/users/aggregate/Passkey.java
@@ -1,0 +1,175 @@
+package com.knight.domain.users.aggregate;
+
+import com.knight.domain.users.types.PasskeyId;
+import com.knight.platform.sharedkernel.UserId;
+
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Passkey entity representing a WebAuthn credential.
+ * Each passkey is associated with a user and contains the credential
+ * information needed for passwordless authentication.
+ */
+public class Passkey {
+
+    private final PasskeyId id;
+    private final UserId userId;
+    private final String credentialId;        // Base64URL encoded credential ID
+    private final String publicKey;           // Base64URL encoded public key (COSE format)
+    private final String aaguid;              // Authenticator Attestation GUID
+    private String displayName;               // User-friendly name for this passkey
+    private long signCount;                   // Signature counter for replay detection
+    private boolean userVerification;         // Whether UV is supported
+    private boolean backupEligible;           // Credential can be backed up
+    private boolean backupState;              // Credential is currently backed up
+    private final String[] transports;        // Authenticator transports (usb, nfc, ble, internal, hybrid)
+    private Instant lastUsedAt;
+    private final Instant createdAt;
+    private Instant updatedAt;
+
+    private Passkey(PasskeyId id, UserId userId, String credentialId, String publicKey,
+                    String aaguid, String displayName, long signCount,
+                    boolean userVerification, boolean backupEligible, boolean backupState,
+                    String[] transports, Instant createdAt) {
+        this.id = Objects.requireNonNull(id, "id cannot be null");
+        this.userId = Objects.requireNonNull(userId, "userId cannot be null");
+        this.credentialId = Objects.requireNonNull(credentialId, "credentialId cannot be null");
+        this.publicKey = Objects.requireNonNull(publicKey, "publicKey cannot be null");
+        this.aaguid = aaguid;
+        this.displayName = displayName;
+        this.signCount = signCount;
+        this.userVerification = userVerification;
+        this.backupEligible = backupEligible;
+        this.backupState = backupState;
+        this.transports = transports != null ? transports.clone() : new String[0];
+        this.createdAt = createdAt;
+        this.updatedAt = createdAt;
+    }
+
+    /**
+     * Factory method to create a new passkey from WebAuthn registration.
+     */
+    public static Passkey create(UserId userId, String credentialId, String publicKey,
+                                  String aaguid, String displayName, long signCount,
+                                  boolean userVerification, boolean backupEligible,
+                                  boolean backupState, String[] transports) {
+        validateCredentialId(credentialId);
+        validatePublicKey(publicKey);
+        return new Passkey(
+            PasskeyId.generate(),
+            userId,
+            credentialId,
+            publicKey,
+            aaguid,
+            displayName != null ? displayName : "Passkey",
+            signCount,
+            userVerification,
+            backupEligible,
+            backupState,
+            transports,
+            Instant.now()
+        );
+    }
+
+    /**
+     * Factory method for reconstitution from persistence.
+     */
+    public static Passkey reconstitute(PasskeyId id, UserId userId, String credentialId,
+                                        String publicKey, String aaguid, String displayName,
+                                        long signCount, boolean userVerification,
+                                        boolean backupEligible, boolean backupState,
+                                        String[] transports, Instant lastUsedAt,
+                                        Instant createdAt, Instant updatedAt) {
+        Passkey passkey = new Passkey(id, userId, credentialId, publicKey, aaguid,
+            displayName, signCount, userVerification, backupEligible, backupState,
+            transports, createdAt);
+        passkey.lastUsedAt = lastUsedAt;
+        passkey.updatedAt = updatedAt;
+        return passkey;
+    }
+
+    private static void validateCredentialId(String credentialId) {
+        if (credentialId == null || credentialId.isBlank()) {
+            throw new IllegalArgumentException("Credential ID is required");
+        }
+        try {
+            Base64.getUrlDecoder().decode(credentialId);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Credential ID must be Base64URL encoded");
+        }
+    }
+
+    private static void validatePublicKey(String publicKey) {
+        if (publicKey == null || publicKey.isBlank()) {
+            throw new IllegalArgumentException("Public key is required");
+        }
+        try {
+            Base64.getUrlDecoder().decode(publicKey);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Public key must be Base64URL encoded");
+        }
+    }
+
+    /**
+     * Update signature counter after successful authentication.
+     * Validates that the new counter is greater than the stored counter
+     * to prevent replay attacks.
+     *
+     * @param newSignCount The new signature counter from authenticator
+     * @throws IllegalStateException if new counter is not greater than stored counter
+     */
+    public void updateSignCount(long newSignCount) {
+        if (newSignCount <= this.signCount) {
+            throw new IllegalStateException(
+                "Signature counter did not increase. Possible cloned authenticator detected.");
+        }
+        this.signCount = newSignCount;
+        this.lastUsedAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Update the display name for this passkey.
+     */
+    public void updateDisplayName(String displayName) {
+        if (displayName == null || displayName.isBlank()) {
+            throw new IllegalArgumentException("Display name is required");
+        }
+        this.displayName = displayName;
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Update backup state (credential may have been synced to cloud).
+     */
+    public void updateBackupState(boolean backupState) {
+        this.backupState = backupState;
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Record that this passkey was used for authentication.
+     */
+    public void recordUsage() {
+        this.lastUsedAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    // Getters
+    public PasskeyId id() { return id; }
+    public UserId userId() { return userId; }
+    public String credentialId() { return credentialId; }
+    public String publicKey() { return publicKey; }
+    public String aaguid() { return aaguid; }
+    public String displayName() { return displayName; }
+    public long signCount() { return signCount; }
+    public boolean userVerification() { return userVerification; }
+    public boolean backupEligible() { return backupEligible; }
+    public boolean backupState() { return backupState; }
+    public String[] transports() { return transports.clone(); }
+    public Instant lastUsedAt() { return lastUsedAt; }
+    public Instant createdAt() { return createdAt; }
+    public Instant updatedAt() { return updatedAt; }
+}

--- a/domain/users/src/main/java/com/knight/domain/users/aggregate/User.java
+++ b/domain/users/src/main/java/com/knight/domain/users/aggregate/User.java
@@ -82,6 +82,11 @@ public class User {
     private Instant lastSyncedAt;
     private Instant lastLoggedInAt;
 
+    // Passkey fields
+    private boolean passkeyOffered;   // User was offered passkey enrollment
+    private boolean passkeyEnrolled;  // User has at least one passkey enrolled
+    private boolean passkeyHasUv;     // User's passkey has user verification capability
+
     // Status tracking
     private Status status;
     private LockType lockType;
@@ -112,6 +117,9 @@ public class User {
         this.emailVerified = false;
         this.passwordSet = false;
         this.mfaEnrolled = false;
+        this.passkeyOffered = false;
+        this.passkeyEnrolled = false;
+        this.passkeyHasUv = false;
         this.createdAt = Instant.now();
         this.updatedAt = this.createdAt;
     }
@@ -128,6 +136,26 @@ public class User {
             Status status, LockType lockType, String lockedBy, Instant lockedAt,
             String deactivationReason,
             Instant createdAt, String createdBy, Instant updatedAt) {
+        return reconstitute(id, loginId, email, firstName, lastName, userType, identityProvider,
+                profileId, roles, identityProviderUserId, emailVerified, passwordSet, mfaEnrolled,
+                lastSyncedAt, lastLoggedInAt, status, lockType, lockedBy, lockedAt, deactivationReason,
+                false, false, false, // passkey defaults
+                createdAt, createdBy, updatedAt);
+    }
+
+    /**
+     * Factory method for reconstitution from persistence with passkey fields.
+     */
+    public static User reconstitute(
+            UserId id, String loginId, String email, String firstName, String lastName,
+            UserType userType, IdentityProvider identityProvider,
+            ProfileId profileId, Set<Role> roles, String identityProviderUserId,
+            boolean emailVerified, boolean passwordSet, boolean mfaEnrolled, Instant lastSyncedAt,
+            Instant lastLoggedInAt,
+            Status status, LockType lockType, String lockedBy, Instant lockedAt,
+            String deactivationReason,
+            boolean passkeyOffered, boolean passkeyEnrolled, boolean passkeyHasUv,
+            Instant createdAt, String createdBy, Instant updatedAt) {
         User user = new User(id, loginId, email, firstName, lastName, userType, identityProvider,
                 profileId, roles, createdBy);
         user.identityProviderUserId = identityProviderUserId;
@@ -141,6 +169,9 @@ public class User {
         user.lockedBy = lockedBy;
         user.lockedAt = lockedAt;
         user.deactivationReason = deactivationReason;
+        user.passkeyOffered = passkeyOffered;
+        user.passkeyEnrolled = passkeyEnrolled;
+        user.passkeyHasUv = passkeyHasUv;
         // Override createdAt and updatedAt from persistence
         try {
             var createdAtField = User.class.getDeclaredField("createdAt");
@@ -394,4 +425,46 @@ public class User {
     public Instant createdAt() { return createdAt; }
     public String createdBy() { return createdBy; }
     public Instant updatedAt() { return updatedAt; }
+    public boolean passkeyOffered() { return passkeyOffered; }
+    public boolean passkeyEnrolled() { return passkeyEnrolled; }
+    public boolean passkeyHasUv() { return passkeyHasUv; }
+
+    // Passkey methods
+
+    /**
+     * Mark that passkey enrollment was offered to this user.
+     * Called after successful login when user is eligible for passkey.
+     */
+    public void markPasskeyOffered() {
+        this.passkeyOffered = true;
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Record successful passkey enrollment.
+     * @param hasUserVerification Whether the passkey has user verification (biometric/PIN)
+     */
+    public void enrollPasskey(boolean hasUserVerification) {
+        this.passkeyEnrolled = true;
+        this.passkeyHasUv = hasUserVerification;
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Record passkey unenrollment (all passkeys removed).
+     */
+    public void unenrollPasskey() {
+        this.passkeyEnrolled = false;
+        this.passkeyHasUv = false;
+        this.updatedAt = Instant.now();
+    }
+
+    /**
+     * Update passkey user verification status.
+     * Called when a new passkey with different UV capability is added.
+     */
+    public void updatePasskeyUv(boolean hasUserVerification) {
+        this.passkeyHasUv = hasUserVerification;
+        this.updatedAt = Instant.now();
+    }
 }

--- a/domain/users/src/main/java/com/knight/domain/users/repository/PasskeyRepository.java
+++ b/domain/users/src/main/java/com/knight/domain/users/repository/PasskeyRepository.java
@@ -1,0 +1,77 @@
+package com.knight.domain.users.repository;
+
+import com.knight.domain.users.aggregate.Passkey;
+import com.knight.domain.users.types.PasskeyId;
+import com.knight.platform.sharedkernel.UserId;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository interface for Passkey persistence.
+ * Implementations handle the actual storage mechanism (JPA, in-memory, etc.)
+ */
+public interface PasskeyRepository {
+
+    /**
+     * Persists a Passkey.
+     *
+     * @param passkey the passkey to save
+     */
+    void save(Passkey passkey);
+
+    /**
+     * Retrieves a Passkey by its identifier.
+     *
+     * @param passkeyId the passkey identifier
+     * @return the passkey if found
+     */
+    Optional<Passkey> findById(PasskeyId passkeyId);
+
+    /**
+     * Retrieves a Passkey by its credential ID.
+     * Credential ID is the unique identifier from the WebAuthn authenticator.
+     *
+     * @param credentialId the Base64URL-encoded credential ID
+     * @return the passkey if found
+     */
+    Optional<Passkey> findByCredentialId(String credentialId);
+
+    /**
+     * Lists all passkeys for a user.
+     *
+     * @param userId the user identifier
+     * @return list of passkeys for the user
+     */
+    List<Passkey> findByUserId(UserId userId);
+
+    /**
+     * Counts passkeys for a user.
+     *
+     * @param userId the user identifier
+     * @return number of passkeys registered for the user
+     */
+    int countByUserId(UserId userId);
+
+    /**
+     * Checks if a user has any passkeys registered.
+     *
+     * @param userId the user identifier
+     * @return true if the user has at least one passkey
+     */
+    boolean existsByUserId(UserId userId);
+
+    /**
+     * Deletes a passkey by ID.
+     *
+     * @param passkeyId the passkey identifier
+     */
+    void deleteById(PasskeyId passkeyId);
+
+    /**
+     * Deletes all passkeys for a user.
+     *
+     * @param userId the user identifier
+     */
+    void deleteByUserId(UserId userId);
+}

--- a/domain/users/src/main/java/com/knight/domain/users/types/PasskeyId.java
+++ b/domain/users/src/main/java/com/knight/domain/users/types/PasskeyId.java
@@ -1,0 +1,31 @@
+package com.knight.domain.users.types;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Value object representing a Passkey identifier.
+ */
+public record PasskeyId(UUID value) {
+
+    public PasskeyId {
+        Objects.requireNonNull(value, "Passkey ID cannot be null");
+    }
+
+    public static PasskeyId generate() {
+        return new PasskeyId(UUID.randomUUID());
+    }
+
+    public static PasskeyId of(String id) {
+        return new PasskeyId(UUID.fromString(id));
+    }
+
+    public String id() {
+        return value.toString();
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <archunit.version>1.4.1</archunit.version>
         <testcontainers.version>1.20.4</testcontainers.version>
         <awaitility.version>4.2.2</awaitility.version>
+        <webauthn4j.version>0.30.2.RELEASE</webauthn4j.version>
     </properties>
 
     <dependencyManagement>
@@ -125,6 +126,13 @@
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <!-- WebAuthn4j for passkey/FIDO2 support -->
+            <dependency>
+                <groupId>com.webauthn4j</groupId>
+                <artifactId>webauthn4j-core</artifactId>
+                <version>${webauthn4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary
Implements GitHub Issue #10: Passkey Enrollment and Authentication

This PR adds local WebAuthn passkey support using the WebAuthn4j library:

- **Domain layer**: `Passkey` entity, `PasskeyId` value object, `PasskeyRepository`, and passkey tracking fields in `User` aggregate
- **Application layer**: `PasskeyService` with WebAuthn4j integration, `PasskeyController` with registration/authentication endpoints, persistence adapters, and passkey configuration properties
- **Client-login**: Nginx proxy endpoints, Lua handler for session creation, 4 new UI screens (enrollment offer, registration, success, authentication), and WebAuthn JavaScript handlers
- **ADR**: Documents the decision to use local WebAuthn implementation instead of Auth0's limited APIs (which require Universal Login or mobile-only Native Passkeys API)

### Key Features
- Passkey enrollment offered after MFA enrollment completion
- Passkey authentication for returning users with enrolled passkeys
- Session creation on successful passkey authentication
- Configurable RP ID, origins, and attestation settings
- Challenge storage with expiration (in-memory, should be Redis in production)

### Files Changed
- 37 files, ~2800 lines added

## Test plan
- [ ] Verify passkey enrollment flow after MFA setup
- [ ] Verify passkey authentication for returning users
- [ ] Verify fallback to password when passkey cancelled
- [ ] Verify passkey skip stores preference
- [ ] Test on Chrome, Safari, and Firefox
- [ ] Test with hardware security keys (if available)

## Notes
- Unit tests for PasskeyService need to be added in a follow-up PR (WebAuthn4j mocking is complex)
- Production deployment should use Redis for challenge storage
- ADR requires security team review before production deployment

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)