### PR TITLE
feat: Passkey Unavailable Fallback Flow

### DIFF
--- a/application/src/main/java/com/knight/application/rest/login/PasskeyFallbackController.java
+++ b/application/src/main/java/com/knight/application/rest/login/PasskeyFallbackController.java
@@ -1,0 +1,143 @@
+package com.knight.application.rest.login;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.knight.application.rest.login.dto.PasskeyFallbackSendOtpRequest;
+import com.knight.application.rest.login.dto.PasskeyFallbackVerifyOtpRequest;
+import com.knight.application.service.otp.OtpResult;
+import com.knight.application.service.otp.OtpService;
+import com.knight.domain.users.aggregate.User;
+import com.knight.domain.users.repository.UserRepository;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+/**
+ * Passkey fallback controller.
+ * Handles OTP verification when a user with enrolled passkey
+ * needs to fall back to password authentication (e.g., on a new device).
+ */
+@RestController
+@RequestMapping("/api/login/passkey-fallback")
+public class PasskeyFallbackController {
+
+    private static final Logger log = LoggerFactory.getLogger(PasskeyFallbackController.class);
+    private static final String OTP_PURPOSE_PASSKEY_FALLBACK = "passkey_fallback";
+
+    private final OtpService otpService;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    public PasskeyFallbackController(OtpService otpService, UserRepository userRepository,
+                                      ObjectMapper objectMapper) {
+        this.otpService = otpService;
+        this.userRepository = userRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Send OTP code for passkey fallback verification.
+     * Called when user clicks "Use password instead" on passkey auth screen.
+     */
+    @PostMapping("/send-otp")
+    public ResponseEntity<ObjectNode> sendOtp(@Valid @RequestBody PasskeyFallbackSendOtpRequest request) {
+        ObjectNode response = objectMapper.createObjectNode();
+
+        // Find user by email
+        Optional<User> userOpt = userRepository.findByEmail(request.email());
+        if (userOpt.isEmpty()) {
+            response.put("error", "user_not_found");
+            response.put("error_description", "User not found");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+        }
+
+        User user = userOpt.get();
+
+        // Verify user has passkey enrolled (this endpoint is only for passkey fallback)
+        if (!user.passkeyEnrolled()) {
+            response.put("error", "invalid_request");
+            response.put("error_description", "User does not have passkey enrolled");
+            return ResponseEntity.badRequest().body(response);
+        }
+
+        // Send OTP
+        String userName = user.firstName() != null ? user.firstName() : user.email();
+        OtpResult result = otpService.sendOtp(user.email(), userName, OTP_PURPOSE_PASSKEY_FALLBACK);
+
+        if (result.isSuccess()) {
+            log.info("Passkey fallback OTP sent for user {}", user.email());
+            response.put("success", true);
+            if (result.expiresInSeconds() != null) {
+                response.put("expires_in_seconds", result.expiresInSeconds());
+            }
+            response.put("masked_email", maskEmail(user.email()));
+            return ResponseEntity.ok(response);
+        } else {
+            response.put("success", false);
+            response.put("error", result.status().name().toLowerCase());
+            response.put("error_description", result.message());
+            if (result.retryAfterSeconds() != null && result.retryAfterSeconds() > 0) {
+                response.put("retry_after_seconds", result.retryAfterSeconds());
+            }
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(response);
+        }
+    }
+
+    /**
+     * Verify OTP code for passkey fallback.
+     * Returns a fallback token that allows password login.
+     */
+    @PostMapping("/verify-otp")
+    public ResponseEntity<ObjectNode> verifyOtp(@Valid @RequestBody PasskeyFallbackVerifyOtpRequest request) {
+        ObjectNode response = objectMapper.createObjectNode();
+
+        // Find user by email
+        Optional<User> userOpt = userRepository.findByEmail(request.email());
+        if (userOpt.isEmpty()) {
+            response.put("error", "user_not_found");
+            response.put("error_description", "User not found");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+        }
+
+        User user = userOpt.get();
+
+        // Verify OTP
+        OtpResult result = otpService.verifyOtp(user.email(), request.code(), OTP_PURPOSE_PASSKEY_FALLBACK);
+
+        if (result.isSuccess()) {
+            log.info("Passkey fallback OTP verified for user {}", user.email());
+            response.put("success", true);
+            response.put("verified", true);
+            // Return a simple token to indicate verification success
+            // The frontend uses this to track that OTP was verified
+            response.put("fallback_token", "verified-" + System.currentTimeMillis());
+            return ResponseEntity.ok(response);
+        } else {
+            response.put("success", false);
+            response.put("error", result.status().name().toLowerCase());
+            response.put("error_description", result.message());
+            if (result.remainingAttempts() != null && result.remainingAttempts() >= 0) {
+                response.put("attempts_remaining", result.remainingAttempts());
+            }
+            return ResponseEntity.badRequest().body(response);
+        }
+    }
+
+    private String maskEmail(String email) {
+        int atIndex = email.indexOf('@');
+        if (atIndex <= 2) {
+            return email;
+        }
+        String localPart = email.substring(0, atIndex);
+        String domain = email.substring(atIndex);
+        if (localPart.length() <= 2) {
+            return localPart.charAt(0) + "*" + domain;
+        }
+        return localPart.charAt(0) + "*".repeat(localPart.length() - 2) + localPart.charAt(localPart.length() - 1) + domain;
+    }
+}

--- a/application/src/main/java/com/knight/application/rest/login/dto/PasskeyFallbackSendOtpRequest.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/PasskeyFallbackSendOtpRequest.java
@@ -1,0 +1,10 @@
+package com.knight.application.rest.login.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasskeyFallbackSendOtpRequest(
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
+    String email
+) {}

--- a/application/src/main/java/com/knight/application/rest/login/dto/PasskeyFallbackVerifyOtpRequest.java
+++ b/application/src/main/java/com/knight/application/rest/login/dto/PasskeyFallbackVerifyOtpRequest.java
@@ -1,0 +1,15 @@
+package com.knight.application.rest.login.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PasskeyFallbackVerifyOtpRequest(
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
+    String email,
+
+    @NotBlank(message = "Code is required")
+    @Size(min = 6, max = 6, message = "Code must be 6 digits")
+    String code
+) {}

--- a/client-login/conf.d/default.conf
+++ b/client-login/conf.d/default.conf
@@ -1088,6 +1088,82 @@ server {
         proxy_set_header Content-Type application/json;
     }
 
+    # ============================================
+    # Passkey Fallback Flow (OTP verification for password fallback)
+    # ============================================
+
+    # Passkey fallback - send OTP
+    location /api/passkey-fallback/send-otp {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/passkey-fallback/send-otp;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
+    # Passkey fallback - verify OTP
+    location /api/passkey-fallback/verify-otp {
+        access_by_lua_block {
+            local origin = ngx.req.get_headers()["Origin"]
+            if origin then
+                local host = ngx.var.scheme .. "://" .. ngx.var.http_host
+                if origin ~= host and origin ~= "http://localhost" and origin ~= "http://localhost:80" and origin ~= "http://localhost:9000" then
+                    ngx.status = 403
+                    ngx.header["Content-Type"] = "application/json"
+                    ngx.say('{"error":"forbidden","error_description":"Cross-origin requests not allowed"}')
+                    return ngx.exit(403)
+                end
+            end
+            if ngx.req.get_method() == "OPTIONS" then
+                ngx.status = 403
+                return ngx.exit(403)
+            end
+            -- Login CSRF validation
+            local csrf = require "csrf"
+            local ok, err = csrf.validate_login()
+            if not ok then
+                ngx.status = 403
+                ngx.header["Content-Type"] = "application/json"
+                ngx.say('{"error":"csrf_error","error_description":"' .. (err or "Login CSRF validation failed") .. '"}')
+                return ngx.exit(403)
+            end
+            -- Set Basic Auth header for auth-service
+            local config = require "config"
+            ngx.req.set_header("Authorization", config.get_auth_service_basic_auth())
+        }
+        proxy_pass $auth_service_url/passkey-fallback/verify-otp;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Content-Type application/json;
+    }
+
     # Forgot password - send password reset email
     location /api/auth/forgot-password {
         content_by_lua_block {

--- a/client-login/login/index.html
+++ b/client-login/login/index.html
@@ -645,6 +645,49 @@
                 </div>
             </div>
 
+            <!-- Screen 20: Passkey Fallback OTP Verification -->
+            <div id="screen-passkey-fallback-otp" class="screen">
+                <div class="login-card-header">
+                    <h1>Verify your identity</h1>
+                    <p>We sent a verification code to <strong id="fallback-otp-email"></strong></p>
+                </div>
+                <div class="login-card-body">
+                    <div id="fallback-otp-error" class="message message-error" style="display: none;"></div>
+                    <div id="fallback-otp-success" class="message message-success" style="display: none;"></div>
+
+                    <p style="text-align: center; color: var(--gray-600); margin-bottom: var(--spacing-lg);">
+                        Since you're signing in without your passkey, please verify your email to continue.
+                    </p>
+
+                    <form id="fallback-otp-form">
+                        <div class="form-group">
+                            <label>Enter the 6-digit code</label>
+                            <div class="otp-container" id="fallback-otp-container">
+                                <input type="text" maxlength="1" class="otp-input" inputmode="numeric" pattern="[0-9]*">
+                                <input type="text" maxlength="1" class="otp-input" inputmode="numeric" pattern="[0-9]*">
+                                <input type="text" maxlength="1" class="otp-input" inputmode="numeric" pattern="[0-9]*">
+                                <input type="text" maxlength="1" class="otp-input" inputmode="numeric" pattern="[0-9]*">
+                                <input type="text" maxlength="1" class="otp-input" inputmode="numeric" pattern="[0-9]*">
+                                <input type="text" maxlength="1" class="otp-input" inputmode="numeric" pattern="[0-9]*">
+                            </div>
+                        </div>
+                        <button type="submit" id="fallback-otp-submit" class="btn btn-primary">
+                            Verify
+                        </button>
+                    </form>
+
+                    <div class="help-link" style="margin-top: var(--spacing-md);">
+                        <span id="fallback-otp-countdown" style="color: var(--gray-600);">Code expires in 5:00</span>
+                    </div>
+                    <div class="help-link">
+                        <a href="#" id="fallback-otp-resend">Resend code</a>
+                    </div>
+                    <div class="help-link">
+                        <a href="#" id="fallback-otp-cancel">Cancel</a>
+                    </div>
+                </div>
+            </div>
+
             <!-- Screen 14: Success -->
             <div id="screen-success" class="screen">
                 <div class="login-card-header">


### PR DESCRIPTION
## Summary
Implements GitHub Issue #11: Passkey Unavailable Fallback Flow

When a user has enrolled a passkey but is on a different device or their passkey is unavailable, they can fall back to password authentication with OTP verification for security.

### Changes
- **Backend**: Added `PasskeyFallbackController` with `/send-otp` and `/verify-otp` endpoints
- **nginx**: Added passkey fallback endpoints to proxy configuration
- **Frontend**: Added fallback OTP screen, handlers, and state management

### Flow
1. User on passkey auth screen clicks "Use password instead"
2. OTP sent to email for verification
3. User verifies OTP on new screen
4. Password screen shown
5. After successful login (+ MFA if required), passkey enrollment offered
6. User can enroll passkey on new device or skip

### Files Changed
- 6 files, ~540 lines added

## Test plan
- [ ] Click "Use password instead" on passkey auth screen
- [ ] Verify OTP is sent to email
- [ ] Verify OTP screen is shown with countdown
- [ ] Enter correct OTP and verify password screen is shown
- [ ] Complete password login (+ MFA if applicable)
- [ ] Verify passkey enrollment is offered after login
- [ ] Test resend OTP functionality
- [ ] Test cancel returns to passkey auth screen

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)