### PR TITLE
feat: Add MFA re-enrollment capability for client admins

### DIFF
--- a/application/src/main/java/com/knight/application/persistence/users/entity/UserEntity.java
+++ b/application/src/main/java/com/knight/application/persistence/users/entity/UserEntity.java
@@ -78,6 +78,15 @@ public class UserEntity {
     @Column(name = "mfa_preference", length = 20)
     private String mfaPreference;
 
+    @Column(name = "allow_mfa_reenrollment", nullable = false)
+    private boolean allowMfaReenrollment;
+
+    @Column(name = "mfa_reenrollment_requested_at")
+    private Instant mfaReenrollmentRequestedAt;
+
+    @Column(name = "mfa_reenrollment_requested_by", length = 255)
+    private String mfaReenrollmentRequestedBy;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 

--- a/application/src/main/java/com/knight/application/persistence/users/mapper/UserMapper.java
+++ b/application/src/main/java/com/knight/application/persistence/users/mapper/UserMapper.java
@@ -37,6 +37,9 @@ public class UserMapper {
         entity.setLockedAt(user.lockedAt());
         entity.setDeactivationReason(user.deactivationReason());
         entity.setMfaPreference(user.mfaPreference() != null ? user.mfaPreference().name() : null);
+        entity.setAllowMfaReenrollment(user.allowMfaReenrollment());
+        entity.setMfaReenrollmentRequestedAt(user.mfaReenrollmentRequestedAt());
+        entity.setMfaReenrollmentRequestedBy(user.mfaReenrollmentRequestedBy());
         entity.setCreatedAt(user.createdAt());
         entity.setCreatedBy(user.createdBy());
         entity.setUpdatedAt(user.updatedAt());
@@ -90,6 +93,9 @@ public class UserMapper {
             entity.getLockedAt(),
             entity.getDeactivationReason(),
             mfaPreference,
+            entity.isAllowMfaReenrollment(),
+            entity.getMfaReenrollmentRequestedAt(),
+            entity.getMfaReenrollmentRequestedBy(),
             entity.getCreatedAt(),
             entity.getCreatedBy(),
             entity.getUpdatedAt()

--- a/application/src/main/java/com/knight/application/rest/client/DirectClientController.java
+++ b/application/src/main/java/com/knight/application/rest/client/DirectClientController.java
@@ -572,6 +572,30 @@ public class DirectClientController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * Reset MFA for user.
+     * Deletes all MFA enrollments in Auth0 and sets allowMfaReenrollment flag.
+     * User will be prompted to enroll MFA again on next login.
+     */
+    @PostMapping("/users/{userId}/reset-mfa")
+    public ResponseEntity<Void> resetUserMfa(@PathVariable String userId) {
+        ProfileId profileId = getProfileIdFromContext();
+        String actor = getUserEmail();
+
+        UserDetail user = userQueries.getUserDetail(UserId.of(userId));
+        if (!user.profileId().equals(profileId.urn())) {
+            return ResponseEntity.notFound().build();
+        }
+
+        userCommands.resetUserMfa(new ResetUserMfaCmd(
+            UserId.of(userId),
+            "Admin MFA reset request",
+            actor
+        ));
+
+        return ResponseEntity.noContent().build();
+    }
+
     @PostMapping("/users/{userId}/roles")
     public ResponseEntity<Void> addRole(
             @PathVariable String userId,

--- a/application/src/main/resources/db/migration/V9__add_mfa_reenrollment.sql
+++ b/application/src/main/resources/db/migration/V9__add_mfa_reenrollment.sql
@@ -1,0 +1,4 @@
+-- Add MFA re-enrollment support for admin MFA reset functionality
+ALTER TABLE users ADD COLUMN allow_mfa_reenrollment BIT NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN mfa_reenrollment_requested_at DATETIME2;
+ALTER TABLE users ADD COLUMN mfa_reenrollment_requested_by NVARCHAR(255);

--- a/application/src/test/java/com/knight/application/rest/indirect/IndirectClientBffControllerTest.java
+++ b/application/src/test/java/com/knight/application/rest/indirect/IndirectClientBffControllerTest.java
@@ -476,7 +476,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 user.id().id(), "testuser", TEST_EMAIL, "Test", "User",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
-                null, Set.of("READER"), true, true,
+                null, Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(user.id())).thenReturn(detail);
@@ -512,7 +512,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 user.id().id(), "testuser", TEST_EMAIL, "Updated", "Name",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
-                null, Set.of("READER"), true, true,
+                null, Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(user.id())).thenReturn(detail);
@@ -591,7 +591,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 "user-1", "testuser", TEST_EMAIL, "Test", "User",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
-                "auth0|123", Set.of("READER"), true, true,
+                "auth0|123", Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
@@ -616,7 +616,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 "user-1", "testuser", TEST_EMAIL, "Test", "User",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", "different-profile-id",
-                null, Set.of("READER"), true, true,
+                null, Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
@@ -639,7 +639,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 "user-1", "testuser", TEST_EMAIL, "Test", "User",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
-                null, Set.of("READER"), true, true,
+                null, Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
@@ -661,7 +661,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 "user-1", "testuser", TEST_EMAIL, "Test", "User",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
-                null, Set.of("READER"), true, true,
+                null, Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
@@ -688,7 +688,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 "user-1", "testuser", TEST_EMAIL, "Test", "User",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
-                null, Set.of("READER"), true, true,
+                null, Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
@@ -722,7 +722,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 "user-1", "testuser", TEST_EMAIL, "Test", "User",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
-                null, Set.of("READER"), true, true,
+                null, Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
@@ -742,7 +742,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 "user-1", "testuser", TEST_EMAIL, "Test", "User",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
-                null, Set.of("READER"), true, true,
+                null, Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
@@ -767,7 +767,7 @@ class IndirectClientBffControllerTest {
             UserDetail detail = new UserDetail(
                 "user-1", "testuser", TEST_EMAIL, "Test", "User",
                 "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
-                null, Set.of("READER"), true, true,
+                null, Set.of("READER"), true, true, false,
                 Instant.now(), "system", null, null, null, null, null, null
             );
             when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
@@ -778,6 +778,51 @@ class IndirectClientBffControllerTest {
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             verify(userCommands).deactivateUser(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /users/{userId}/reset-mfa")
+    class ResetUserMfaTests {
+
+        @Test
+        @DisplayName("should reset MFA for user in profile")
+        void shouldResetMfaForUserInProfile() {
+            when(auth0UserContext.getProfileId()).thenReturn(Optional.of(TEST_PROFILE_ID));
+            when(auth0UserContext.getUserEmail()).thenReturn(Optional.of(TEST_EMAIL));
+
+            UserDetail detail = new UserDetail(
+                "user-1", "testuser", TEST_EMAIL, "Test", "User",
+                "ACTIVE", "INDIRECT_USER", "AUTH0", TEST_PROFILE_ID.urn(),
+                "auth0|123", Set.of("READER"), true, true, false,
+                Instant.now(), "system", null, null, null, null, null, null
+            );
+            when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
+
+            ResponseEntity<Void> response = controller.resetUserMfa("user-1");
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(userCommands).resetUserMfa(any());
+        }
+
+        @Test
+        @DisplayName("should return 404 when user not in profile")
+        void shouldReturn404WhenUserNotInProfile() {
+            when(auth0UserContext.getProfileId()).thenReturn(Optional.of(TEST_PROFILE_ID));
+            when(auth0UserContext.getUserEmail()).thenReturn(Optional.of(TEST_EMAIL));
+
+            UserDetail detail = new UserDetail(
+                "user-1", "testuser", TEST_EMAIL, "Test", "User",
+                "ACTIVE", "INDIRECT_USER", "AUTH0", "different-profile-id",
+                "auth0|123", Set.of("READER"), true, true, false,
+                Instant.now(), "system", null, null, null, null, null, null
+            );
+            when(userQueries.getUserDetail(UserId.of("user-1"))).thenReturn(detail);
+
+            ResponseEntity<Void> response = controller.resetUserMfa("user-1");
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            verify(userCommands, never()).resetUserMfa(any());
         }
     }
 

--- a/domain/auth0-identity/src/main/java/com/knight/domain/auth0identity/api/Auth0IdentityService.java
+++ b/domain/auth0-identity/src/main/java/com/knight/domain/auth0identity/api/Auth0IdentityService.java
@@ -145,6 +145,16 @@ public interface Auth0IdentityService {
      */
     void sendPasswordResetEmail(String email);
 
+    // ==================== MFA Management ====================
+
+    /**
+     * Deletes all MFA enrollments for a user.
+     * Called when admin resets MFA for a user.
+     *
+     * @param auth0UserId the Auth0 user ID
+     */
+    void deleteAllMfaEnrollments(String auth0UserId);
+
     /**
      * Links the Auth0 user to an internal user ID.
      *

--- a/domain/users/src/main/java/com/knight/domain/users/api/commands/UserCommands.java
+++ b/domain/users/src/main/java/com/knight/domain/users/api/commands/UserCommands.java
@@ -109,4 +109,29 @@ public interface UserCommands {
     record UpdateUserEmailCmd(UserId userId, String newEmail, String updatedBy) {}
 
     record UpdateEmailResult(String previousEmail, String newEmail) {}
+
+    // ==================== MFA Re-enrollment ====================
+
+    /**
+     * Reset MFA for a user (admin operation).
+     * Sets allowMfaReenrollment flag and mfaEnrolled to false.
+     * Should also delete MFA enrollments from Auth0.
+     */
+    void resetUserMfa(ResetUserMfaCmd cmd);
+
+    record ResetUserMfaCmd(UserId userId, String reason, String actor) {}
+
+    /**
+     * Clear MFA re-enrollment requirement after successful enrollment.
+     */
+    void clearMfaReenrollment(ClearMfaReenrollmentCmd cmd);
+
+    record ClearMfaReenrollmentCmd(UserId userId) {}
+
+    /**
+     * Complete MFA re-enrollment with the chosen MFA method.
+     */
+    void completeMfaReenrollment(CompleteMfaReenrollmentCmd cmd);
+
+    record CompleteMfaReenrollmentCmd(UserId userId, String mfaPreference) {}
 }

--- a/domain/users/src/main/java/com/knight/domain/users/api/queries/UserQueries.java
+++ b/domain/users/src/main/java/com/knight/domain/users/api/queries/UserQueries.java
@@ -60,6 +60,7 @@ public interface UserQueries {
         Set<String> roles,
         boolean passwordSet,
         boolean mfaEnrolled,
+        boolean allowMfaReenrollment,
         Instant createdAt,
         String createdBy,
         Instant lastSyncedAt,


### PR DESCRIPTION
## Summary

Implements US-AUTH-030 through US-AUTH-034 to allow client admins to reset MFA for users who lose access to their authenticator device.

- **US-AUTH-030**: Add `allowMfaReenrollment` flag and related fields to User aggregate
- **US-AUTH-031**: Add MFA reset endpoint for indirect client admins (`POST /api/indirect/users/{userId}/reset-mfa`)
- **US-AUTH-032**: Add MFA reset endpoint for direct client admins (`POST /api/direct/users/{userId}/reset-mfa`)
- **US-AUTH-033/034**: Login flow changes require lua/nginx modifications in client-login module (not included)

### Changes

**Domain Layer:**
- User aggregate: `requestMfaReenrollment()`, `clearMfaReenrollment()`, `completeMfaReenrollment()`
- New fields: `allowMfaReenrollment`, `mfaReenrollmentRequestedAt`, `mfaReenrollmentRequestedBy`
- `ResetUserMfaCmd` command and application service implementation

**Auth0 Integration:**
- `deleteAllMfaEnrollments()` to delete MFA enrollments via Management API

**REST Endpoints:**
- `POST /api/indirect/users/{userId}/reset-mfa` - Indirect client admin resets user MFA
- `POST /api/direct/users/{userId}/reset-mfa` - Direct client admin resets user MFA

**Database Migration:**
- V9: Adds `allow_mfa_reenrollment`, `mfa_reenrollment_requested_at`, `mfa_reenrollment_requested_by` columns

## Test Coverage

| Module | Line Coverage | Branch Coverage |
|--------|---------------|-----------------|
| domain/users | 97.0% | 92.6% |
| domain/clients | 84.3% | 84.2% |
| domain/profiles | 97.3% | 90.0% |
| kernel | 97.8% | 94.7% |
| application | 87.3% | 79.0% |

## Test plan

- [x] Unit tests for User aggregate MFA re-enrollment methods
- [x] Unit tests for UserApplicationService resetUserMfa
- [x] Controller tests for IndirectClientBffController reset-mfa endpoint
- [x] Controller tests for DirectClientController reset-mfa endpoint
- [x] All existing tests pass (1155+ tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)