### PR TITLE
fix: Enable global user lookup to resolve 'User not found' on direct navigation

### DIFF
--- a/application/src/main/java/com/knight/application/rest/bank/BankAdminController.java
+++ b/application/src/main/java/com/knight/application/rest/bank/BankAdminController.java
@@ -667,6 +667,14 @@ public class BankAdminController {
         return ResponseEntity.ok(toUserDetailDto(user));
     }
 
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<UserDetailDto> getGlobalUserDetail(
+            @PathVariable String userId) {
+        log.info("Getting global user detail for {}", userId);
+        UserDetail user = userQueries.getUserDetail(UserId.of(userId));
+        return ResponseEntity.ok(toUserDetailDto(user));
+    }
+
     @GetMapping("/profiles/{profileId}/users/counts")
     public ResponseEntity<Map<String, Integer>> getUserCounts(
             @PathVariable String profileId) {

--- a/employee-portal/src/main/java/com/knight/portal/services/UserService.java
+++ b/employee-portal/src/main/java/com/knight/portal/services/UserService.java
@@ -55,6 +55,27 @@ public class UserService {
     }
 
     /**
+     * Get user details globally (without profile ID).
+     */
+    public UserDetail getGlobalUserDetail(String userId) {
+        try {
+            Map<String, Object> response = restClient.get()
+                    .uri("/api/v1/bank/users/{userId}", userId)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<Map<String, Object>>() {});
+
+            if (response == null) {
+                return null;
+            }
+
+            return objectMapper.convertValue(response, UserDetail.class);
+        } catch (Exception e) {
+            System.err.println("Error fetching global user detail: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Get user details.
      */
     public UserDetail getUserDetail(String profileId, String userId) {

--- a/employee-portal/src/main/java/com/knight/portal/services/dto/ProfileUser.java
+++ b/employee-portal/src/main/java/com/knight/portal/services/dto/ProfileUser.java
@@ -1,11 +1,13 @@
 package com.knight.portal.services.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.Instant;
 import java.util.Set;
 
 /**
  * User summary for profile users list.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ProfileUser {
     private String userId;
     private String loginId;

--- a/employee-portal/src/main/java/com/knight/portal/services/dto/UserDetail.java
+++ b/employee-portal/src/main/java/com/knight/portal/services/dto/UserDetail.java
@@ -1,13 +1,16 @@
 package com.knight.portal.services.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.Instant;
 import java.util.Set;
 
 /**
  * Detailed user information.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserDetail {
     private String userId;
+    private String loginId;
     private String email;
     private String firstName;
     private String lastName;
@@ -19,15 +22,22 @@ public class UserDetail {
     private Set<String> roles;
     private boolean passwordSet;
     private boolean mfaEnrolled;
+    private boolean allowMfaReenrollment;
     private Instant createdAt;
     private String createdBy;
     private Instant lastSyncedAt;
-    private String lockReason;
+    private Instant lastLoggedInAt;
+    private String lockType;
+    private String lockedBy;
+    private Instant lockedAt;
     private String deactivationReason;
 
     // Getters and setters
     public String getUserId() { return userId; }
     public void setUserId(String userId) { this.userId = userId; }
+
+    public String getLoginId() { return loginId; }
+    public void setLoginId(String loginId) { this.loginId = loginId; }
 
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
@@ -69,6 +79,9 @@ public class UserDetail {
     public boolean isMfaEnrolled() { return mfaEnrolled; }
     public void setMfaEnrolled(boolean mfaEnrolled) { this.mfaEnrolled = mfaEnrolled; }
 
+    public boolean isAllowMfaReenrollment() { return allowMfaReenrollment; }
+    public void setAllowMfaReenrollment(boolean allowMfaReenrollment) { this.allowMfaReenrollment = allowMfaReenrollment; }
+
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
 
@@ -78,8 +91,17 @@ public class UserDetail {
     public Instant getLastSyncedAt() { return lastSyncedAt; }
     public void setLastSyncedAt(Instant lastSyncedAt) { this.lastSyncedAt = lastSyncedAt; }
 
-    public String getLockReason() { return lockReason; }
-    public void setLockReason(String lockReason) { this.lockReason = lockReason; }
+    public Instant getLastLoggedInAt() { return lastLoggedInAt; }
+    public void setLastLoggedInAt(Instant lastLoggedInAt) { this.lastLoggedInAt = lastLoggedInAt; }
+
+    public String getLockType() { return lockType; }
+    public void setLockType(String lockType) { this.lockType = lockType; }
+
+    public String getLockedBy() { return lockedBy; }
+    public void setLockedBy(String lockedBy) { this.lockedBy = lockedBy; }
+
+    public Instant getLockedAt() { return lockedAt; }
+    public void setLockedAt(Instant lockedAt) { this.lockedAt = lockedAt; }
 
     public String getDeactivationReason() { return deactivationReason; }
     public void setDeactivationReason(String deactivationReason) { this.deactivationReason = deactivationReason; }

--- a/employee-portal/src/main/java/com/knight/portal/views/UserDetailView.java
+++ b/employee-portal/src/main/java/com/knight/portal/views/UserDetailView.java
@@ -135,10 +135,17 @@ public class UserDetailView extends VerticalLayout implements HasUrlParameter<St
     }
 
     private void loadUserDetails() {
-        if (userId == null || profileId == null) return;
+        if (userId == null) return;
 
         try {
-            userDetail = userService.getUserDetail(profileId, userId);
+            if (profileId != null) {
+                userDetail = userService.getUserDetail(profileId, userId);
+            } else {
+                userDetail = userService.getGlobalUserDetail(userId);
+                if (userDetail != null) {
+                    profileId = userDetail.getProfileId();
+                }
+            }
 
             if (userDetail != null) {
                 // Initialize permission state from user roles
@@ -150,11 +157,13 @@ public class UserDetailView extends VerticalLayout implements HasUrlParameter<St
             }
 
             // Load profile details to get available accounts
-            profileDetail = profileService.getProfileDetail(profileId);
-            if (profileDetail != null && profileDetail.getAccountEnrollments() != null) {
-                availableAccounts = profileDetail.getAccountEnrollments().stream()
-                        .filter(ae -> "ACTIVE".equals(ae.getStatus()))
-                        .toList();
+            if (profileId != null) {
+                profileDetail = profileService.getProfileDetail(profileId);
+                if (profileDetail != null && profileDetail.getAccountEnrollments() != null) {
+                    availableAccounts = profileDetail.getAccountEnrollments().stream()
+                            .filter(ae -> "ACTIVE".equals(ae.getStatus()))
+                            .toList();
+                }
             }
         } catch (Exception e) {
             Notification notification = Notification.show("Error loading user: " + e.getMessage());


### PR DESCRIPTION
This PR resolves #40 by adding a global user lookup endpoint and updating the frontend to handle direct URL navigation to user details without a profile ID context.