### PR TITLE
fix: Use email as loginId in payor enrolment (Fixes #47)

### DIFF
--- a/application/src/main/java/com/knight/application/service/PayorEnrolmentProcessorImpl.java
+++ b/application/src/main/java/com/knight/application/service/PayorEnrolmentProcessorImpl.java
@@ -108,13 +108,8 @@ public class PayorEnrolmentProcessorImpl implements PayorEnrolmentProcessor {
                 String firstName = nameParts[0];
                 String lastName = nameParts.length > 1 ? nameParts[1] : "";
 
-                // Generate loginId from email (everything before @)
-                String loginId = person.email().split("@")[0].replaceAll("[^a-zA-Z0-9_]", "_");
-                if (loginId.length() < 3) {
-                    loginId = loginId + "_user";
-                } else if (loginId.length() > 50) {
-                    loginId = loginId.substring(0, 50);
-                }
+                // Use email as loginId (loginId must be valid email format for Auth0)
+                String loginId = person.email();
 
                 UserId userId = userCommands.createUser(new UserCommands.CreateUserCmd(
                         loginId,


### PR DESCRIPTION
## Summary
- Fixed payor enrolment import failing with "Login ID must be a valid email format" error
- Changed loginId generation to use the full email address instead of extracting just the prefix before @
- This aligns with the auth cleanup changes that require loginId to be a valid email format for Auth0

## Test plan
- [x] Batch domain tests pass (64 tests)
- [ ] Re-run payor enrollment import to verify records are created successfully
- [ ] Verify users can authenticate with their email as loginId

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)